### PR TITLE
chore: GitHub Actions CI workflow 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+        
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      
+      - name: Run lint
+        run: pnpm lint
+
+      - name: Run build
+        run: pnpm build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+pnpm lint
+pnpm build

--- a/biome.json
+++ b/biome.json
@@ -22,11 +22,22 @@
         "noNonNullAssertion": "warn"
       },
       "suspicious": {
-        "noExplicitAny": "warn"
+        "noExplicitAny": "warn",
+        "noUnknownAtRules": {
+          "level": "error",
+          "options": {
+            "ignore": ["tailwind"]
+          }
+        }
       },
       "correctness": {
         "noUnusedVariables": "warn"
       }
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
     }
   },
   "javascript": {


### PR DESCRIPTION
## 작업 내용
- GitHub Actions CI와 로컬 pre-push 검사를 추가하고, Biome에서 Tailwind CSS 문법을 인식할 수 있도록 설정을 보완했습니다.

## 상세 변경 사항
- `.github/workflows/ci.yml` 파일을 추가해 PR 및 지정 브랜치 push 시 lint, build가 실행되도록 설정했습니다.
- `.husky/pre-push` 파일을 추가해 push 전에 `pnpm lint`, `pnpm build`가 실행되도록 설정했습니다.
- `biome.json`에 Tailwind CSS 관련 설정을 추가해 `@tailwind`, `@apply` 등 전용 문법이 lint 에러로 처리되지 않도록 보완했습니다.

## 관련 이슈
- closes #8

## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?
