### PR TITLE
레디스 게임 상태 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env.*
 !.env.example
 *.tsbuildinfo
+.vscode

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -27,7 +27,8 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.10",

--- a/apps/backend/src/common/constants/socket-events.ts
+++ b/apps/backend/src/common/constants/socket-events.ts
@@ -1,6 +1,13 @@
 export const SOCKET_EVENTS = {
+  BATTLE_COUNTDOWN: "battle:countdown",
+  BATTLE_FINISHED: "battle:finished",
+  BATTLE_JOIN: "battle:join",
   BATTLE_READY: "battle:ready",
   BATTLE_READY_CONFIRMED: "battle:ready-confirmed",
   BATTLE_PLAYER_READY: "battle:player-ready",
+  BATTLE_SPECTATE: "battle:spectate",
+  BATTLE_STARTED: "battle:started",
+  BATTLE_STATE: "battle:state",
+  BATTLE_WAITING: "battle:waiting",
   BATTLE_WELCOME: "battle:welcome",
 } as const;

--- a/apps/backend/src/modules/battle/battle.module.ts
+++ b/apps/backend/src/modules/battle/battle.module.ts
@@ -1,8 +1,17 @@
 import { Module } from "@nestjs/common";
 import { BattleGateway } from "./gateways/battle.gateway";
+import { BattleStateRepository } from "./repositories/battle-state.repository";
 import { BattleService } from "./services/battle.service";
+import { BattleBroadcastService } from "./services/battle-broadcast.service";
+import { BattleCycleService } from "./services/battle-cycle.service";
 
 @Module({
-  providers: [BattleGateway, BattleService],
+  providers: [
+    BattleBroadcastService,
+    BattleCycleService,
+    BattleGateway,
+    BattleService,
+    BattleStateRepository,
+  ],
 })
 export class BattleModule {}

--- a/apps/backend/src/modules/battle/gateways/battle.gateway.ts
+++ b/apps/backend/src/modules/battle/gateways/battle.gateway.ts
@@ -8,9 +8,9 @@ import {
 } from "@nestjs/websockets";
 import type { Server, Socket } from "socket.io";
 import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
-import type { BattleReadyDto } from "../dto/battle-ready.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
-import { BattleService } from "../services/battle.service";
+import type { BattleReadyDto } from "../dto/battle-ready.dto";
+import type { BattleService } from "../services/battle.service";
 
 @WebSocketGateway({
   cors: {
@@ -23,19 +23,20 @@ export class BattleGateway implements OnGatewayConnection {
   @WebSocketServer()
   server!: Server;
 
-  handleConnection(client: Socket) {
-    client.emit(SOCKET_EVENTS.BATTLE_WELCOME, this.battleService.getWelcomeMessage());
+  async handleConnection(client: Socket) {
+    const connectionState = await this.battleService.getConnectionState();
+
+    client.emit(SOCKET_EVENTS.BATTLE_WELCOME, {
+      ...this.battleService.getWelcomeMessage(),
+      game: connectionState,
+    });
   }
 
   @SubscribeMessage(SOCKET_EVENTS.BATTLE_READY)
   handleReady(@MessageBody() payload: BattleReadyDto, @ConnectedSocket() client: Socket) {
     const confirmed = this.battleService.createReadyConfirmation(payload);
 
+    client.emit(SOCKET_EVENTS.BATTLE_READY_CONFIRMED, confirmed);
     client.broadcast.emit(SOCKET_EVENTS.BATTLE_PLAYER_READY, payload);
-
-    return {
-      event: SOCKET_EVENTS.BATTLE_READY_CONFIRMED,
-      data: confirmed,
-    };
   }
 }

--- a/apps/backend/src/modules/battle/gateways/battle.gateway.ts
+++ b/apps/backend/src/modules/battle/gateways/battle.gateway.ts
@@ -1,15 +1,6 @@
-import {
-  ConnectedSocket,
-  MessageBody,
-  type OnGatewayConnection,
-  SubscribeMessage,
-  WebSocketGateway,
-  WebSocketServer,
-} from "@nestjs/websockets";
+import { type OnGatewayConnection, WebSocketGateway, WebSocketServer } from "@nestjs/websockets";
 import type { Server, Socket } from "socket.io";
-import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
-import type { BattleReadyDto } from "../dto/battle-ready.dto";
 import type { BattleService } from "../services/battle.service";
 
 @WebSocketGateway({
@@ -24,19 +15,14 @@ export class BattleGateway implements OnGatewayConnection {
   server!: Server;
 
   async handleConnection(client: Socket) {
-    const connectionState = await this.battleService.getConnectionState();
-
-    client.emit(SOCKET_EVENTS.BATTLE_WELCOME, {
-      ...this.battleService.getWelcomeMessage(),
-      game: connectionState,
-    });
-  }
-
-  @SubscribeMessage(SOCKET_EVENTS.BATTLE_READY)
-  handleReady(@MessageBody() payload: BattleReadyDto, @ConnectedSocket() client: Socket) {
-    const confirmed = this.battleService.createReadyConfirmation(payload);
-
-    client.emit(SOCKET_EVENTS.BATTLE_READY_CONFIRMED, confirmed);
-    client.broadcast.emit(SOCKET_EVENTS.BATTLE_PLAYER_READY, payload);
+    let currentGameState = await this.battleService.getCurrentGameState();
+    if (!currentGameState) {
+      currentGameState = await this.battleService.startNewGame();
+    }
+    if (currentGameState?.phase === "waiting") {
+      client.emit("battle:join", currentGameState);
+    } else if (currentGameState?.phase === "in_progress") {
+      client.emit("battle:spectate", currentGameState);
+    }
   }
 }

--- a/apps/backend/src/modules/battle/gateways/battle.gateway.ts
+++ b/apps/backend/src/modules/battle/gateways/battle.gateway.ts
@@ -1,28 +1,69 @@
-import { type OnGatewayConnection, WebSocketGateway, WebSocketServer } from "@nestjs/websockets";
+import {
+  ConnectedSocket,
+  MessageBody,
+  type OnGatewayConnection,
+  type OnGatewayDisconnect,
+  type OnGatewayInit,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from "@nestjs/websockets";
 import type { Server, Socket } from "socket.io";
+import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
+import type { BattleReadyDto } from "../dto/battle-ready.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
-import type { BattleService } from "../services/battle.service";
+import { BattleService } from "../services/battle.service";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { BattleBroadcastService } from "../services/battle-broadcast.service";
 
 @WebSocketGateway({
   cors: {
     origin: "*",
   },
 })
-export class BattleGateway implements OnGatewayConnection {
-  constructor(private readonly battleService: BattleService) {}
+export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit {
+  constructor(
+    private readonly battleBroadcastService: BattleBroadcastService,
+    private readonly battleService: BattleService,
+  ) {}
 
   @WebSocketServer()
   server!: Server;
 
+  afterInit(server: Server) {
+    this.battleBroadcastService.setServer(server);
+  }
+
   async handleConnection(client: Socket) {
-    let currentGameState = await this.battleService.getCurrentGameState();
-    if (!currentGameState) {
-      currentGameState = await this.battleService.startNewGame();
+    const connectionState = await this.battleService.registerConnection();
+
+    client.data.assignedRole = connectionState.assignedRole;
+    client.emit(SOCKET_EVENTS.BATTLE_WELCOME, {
+      ...this.battleService.getWelcomeMessage(),
+      assignedRole: connectionState.assignedRole,
+    });
+    client.emit(
+      connectionState.assignedRole === "player"
+        ? SOCKET_EVENTS.BATTLE_JOIN
+        : SOCKET_EVENTS.BATTLE_SPECTATE,
+      connectionState,
+    );
+    client.emit(SOCKET_EVENTS.BATTLE_STATE, connectionState.state);
+
+    if (connectionState.waiting) {
+      client.emit(SOCKET_EVENTS.BATTLE_WAITING, connectionState.waiting);
     }
-    if (currentGameState?.phase === "waiting") {
-      client.emit("battle:join", currentGameState);
-    } else if (currentGameState?.phase === "in_progress") {
-      client.emit("battle:spectate", currentGameState);
-    }
+  }
+
+  async handleDisconnect(client: Socket) {
+    await this.battleService.unregisterConnection(client.data.assignedRole);
+  }
+
+  @SubscribeMessage(SOCKET_EVENTS.BATTLE_READY)
+  handleReady(@MessageBody() payload: BattleReadyDto, @ConnectedSocket() client: Socket) {
+    const confirmed = this.battleService.createReadyConfirmation(payload);
+
+    client.emit(SOCKET_EVENTS.BATTLE_READY_CONFIRMED, confirmed);
+    client.broadcast.emit(SOCKET_EVENTS.BATTLE_PLAYER_READY, payload);
   }
 }

--- a/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
+++ b/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
@@ -4,10 +4,23 @@ import { RedisService } from "../../storage/redis/redis.service";
 import type { CurrentGameState } from "../types/current-game-state";
 
 const CURRENT_GAME_ID_KEY = "battle:current-game-id";
+const BATTLE_TIMER_LOCK_KEY = "battle:timer-lock";
 
 @Injectable()
 export class BattleStateRepository {
   constructor(private readonly redisService: RedisService) {}
+
+  async acquireTimerLock(lockToken: string, ttlSeconds: number) {
+    const result = await this.redisService.instance.set(
+      BATTLE_TIMER_LOCK_KEY,
+      lockToken,
+      "EX",
+      ttlSeconds,
+      "NX",
+    );
+
+    return result === "OK";
+  }
 
   async setCurrentGameId(gameId: string) {
     await this.redisService.instance.set(CURRENT_GAME_ID_KEY, gameId);
@@ -17,11 +30,26 @@ export class BattleStateRepository {
     return this.redisService.instance.get(CURRENT_GAME_ID_KEY);
   }
 
+  async saveCurrentGameState(gameState: CurrentGameState) {
+    await this.setCurrentGameId(gameState.gameId);
+    await this.setCurrentGameState(gameState.gameId, gameState);
+  }
+
   async setCurrentGameState(gameId: string, gameState: CurrentGameState) {
     await this.redisService.instance.set(`battle:game:${gameId}:state`, JSON.stringify(gameState));
   }
 
-  async getCurrentGameState(gameId: string) {
+  async getCurrentGameState() {
+    const currentGameId = await this.getCurrentGameId();
+
+    if (!currentGameId) {
+      return null;
+    }
+
+    return this.getCurrentGameStateById(currentGameId);
+  }
+
+  async getCurrentGameStateById(gameId: string) {
     const value = await this.redisService.instance.get(`battle:game:${gameId}:state`);
 
     if (!value) {

--- a/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
+++ b/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
@@ -1,0 +1,33 @@
+import { Injectable } from "@nestjs/common";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { RedisService } from "../../storage/redis/redis.service";
+import type { CurrentGameState } from "../types/current-game-state";
+
+const CURRENT_GAME_ID_KEY = "battle:current-game-id";
+
+@Injectable()
+export class BattleStateRepository {
+  constructor(private readonly redisService: RedisService) {}
+
+  async setCurrentGameId(gameId: string) {
+    await this.redisService.instance.set(CURRENT_GAME_ID_KEY, gameId);
+  }
+
+  async getCurrentGameId() {
+    return this.redisService.instance.get(CURRENT_GAME_ID_KEY);
+  }
+
+  async setCurrentGameState(gameId: string, gameState: CurrentGameState) {
+    await this.redisService.instance.set(`battle:game:${gameId}:state`, JSON.stringify(gameState));
+  }
+
+  async getCurrentGameState(gameId: string) {
+    const value = await this.redisService.instance.get(`battle:game:${gameId}:state`);
+
+    if (!value) {
+      return null;
+    }
+
+    return JSON.parse(value) as CurrentGameState;
+  }
+}

--- a/apps/backend/src/modules/battle/services/battle-broadcast.service.ts
+++ b/apps/backend/src/modules/battle/services/battle-broadcast.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@nestjs/common";
+import type { Server } from "socket.io";
+
+@Injectable()
+export class BattleBroadcastService {
+  private server: null | Server = null;
+
+  emitToAll(event: string, payload: unknown) {
+    this.server?.emit(event, payload);
+  }
+
+  setServer(server: Server) {
+    this.server = server;
+  }
+}

--- a/apps/backend/src/modules/battle/services/battle-cycle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle-cycle.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { v7 as uuidv7 } from "uuid";
+import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { BattleStateRepository } from "../repositories/battle-state.repository";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { BattleService } from "./battle.service";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { BattleBroadcastService } from "./battle-broadcast.service";
+
+const TEN_SECOND_NOTICE_THRESHOLD = 10;
+const TIMER_INTERVAL_MILLISECONDS = 1000;
+const TIMER_LOCK_TTL_SECONDS = 2;
+
+@Injectable()
+export class BattleCycleService implements OnModuleDestroy, OnModuleInit {
+  private readonly logger = new Logger(BattleCycleService.name);
+
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly battleBroadcastService: BattleBroadcastService,
+    private readonly battleService: BattleService,
+    private readonly battleStateRepository: BattleStateRepository,
+  ) {}
+
+  async onModuleInit() {
+    await this.battleService.ensureCurrentGameState();
+    this.startTimer();
+  }
+
+  onModuleDestroy() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async finishCurrentGame() {
+    const finishedResult = await this.battleService.finishCurrentGame();
+
+    if (!finishedResult) {
+      return null;
+    }
+
+    this.logger.log(`Finished game ${finishedResult.finishedGameState.gameId}`);
+    this.battleBroadcastService.emitToAll(
+      SOCKET_EVENTS.BATTLE_FINISHED,
+      this.battleService.buildStatePayload(finishedResult.finishedGameState),
+    );
+    this.battleBroadcastService.emitToAll(
+      SOCKET_EVENTS.BATTLE_WAITING,
+      this.battleService.buildWaitingPayload(finishedResult.nextWaitingGameState),
+    );
+
+    return finishedResult;
+  }
+
+  private async handleTimerTick() {
+    const hasLock = await this.battleStateRepository.acquireTimerLock(
+      uuidv7(),
+      TIMER_LOCK_TTL_SECONDS,
+    );
+
+    if (!hasLock) {
+      return;
+    }
+
+    const currentGameState = await this.battleService.ensureCurrentGameState();
+
+    if (currentGameState.phase !== "waiting") {
+      return;
+    }
+
+    const remainingSeconds = this.battleService.getWaitingRemainingSeconds(currentGameState);
+
+    if (remainingSeconds === 0) {
+      const startedGameState = await this.battleService.startCurrentGame(currentGameState);
+
+      this.logger.log(`Started game ${startedGameState.gameId}`);
+      this.battleBroadcastService.emitToAll(
+        SOCKET_EVENTS.BATTLE_STARTED,
+        this.battleService.buildStatePayload(startedGameState),
+      );
+      this.battleBroadcastService.emitToAll(
+        SOCKET_EVENTS.BATTLE_STATE,
+        this.battleService.buildStatePayload(startedGameState),
+      );
+
+      return;
+    }
+
+    if (
+      remainingSeconds <= TEN_SECOND_NOTICE_THRESHOLD &&
+      !currentGameState.hasTenSecondNoticeSent
+    ) {
+      const updatedGameState = await this.battleService.markTenSecondNoticeSent(currentGameState);
+
+      this.battleBroadcastService.emitToAll(
+        SOCKET_EVENTS.BATTLE_COUNTDOWN,
+        this.battleService.buildWaitingPayload(updatedGameState),
+      );
+      this.battleBroadcastService.emitToAll(
+        SOCKET_EVENTS.BATTLE_STATE,
+        this.battleService.buildStatePayload(updatedGameState),
+      );
+    }
+
+    this.battleBroadcastService.emitToAll(
+      SOCKET_EVENTS.BATTLE_WAITING,
+      this.battleService.buildWaitingPayload(currentGameState),
+    );
+  }
+
+  private startTimer() {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+
+    this.timer = setInterval(() => {
+      void this.handleTimerTick();
+    }, TIMER_INTERVAL_MILLISECONDS);
+  }
+}

--- a/apps/backend/src/modules/battle/services/battle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle.service.ts
@@ -1,35 +1,207 @@
 import { Injectable } from "@nestjs/common";
 import { v7 as uuidv7 } from "uuid";
+import type { BattleReadyDto } from "../dto/battle-ready.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { BattleStateRepository } from "../repositories/battle-state.repository";
+import type { ConnectionRole, CurrentGameState } from "../types/current-game-state";
+
+const WAITING_DURATION_SECONDS = 15 * 60;
 
 @Injectable()
 export class BattleService {
   constructor(private readonly battleStateRepository: BattleStateRepository) {}
 
-  async startNewGame() {
+  async ensureCurrentGameState() {
+    const currentGameState = await this.battleStateRepository.getCurrentGameState();
+
+    if (currentGameState && currentGameState.phase !== "finished") {
+      return currentGameState;
+    }
+
+    const waitingGameState = this.createWaitingGameState(new Date());
+    await this.battleStateRepository.saveCurrentGameState(waitingGameState);
+
+    return waitingGameState;
+  }
+
+  createReadyConfirmation(payload: BattleReadyDto) {
+    return {
+      nickname: payload.nickname,
+      status: "queued" as const,
+    };
+  }
+
+  getWelcomeMessage() {
+    return {
+      message: "Keyboard Warrior Battle Royale server connected",
+    };
+  }
+
+  async getCurrentGameState() {
+    return this.battleStateRepository.getCurrentGameState();
+  }
+
+  getWaitingRemainingSeconds(currentGameState: CurrentGameState) {
+    if (!currentGameState.waitingEndsAt) {
+      return 0;
+    }
+
+    const remainingMilliseconds = new Date(currentGameState.waitingEndsAt).getTime() - Date.now();
+
+    return Math.max(0, Math.ceil(remainingMilliseconds / 1000));
+  }
+
+  buildStatePayload(currentGameState: CurrentGameState) {
+    return {
+      gameId: currentGameState.gameId,
+      phase: currentGameState.phase,
+      minPlayers: currentGameState.minPlayers,
+      playerCount: currentGameState.playerCount,
+      spectatorCount: currentGameState.spectatorCount,
+      waitingEndsAt: currentGameState.waitingEndsAt,
+      gameStartedAt: currentGameState.gameStartedAt,
+      gameEndedAt: currentGameState.gameEndedAt,
+    };
+  }
+
+  buildWaitingPayload(currentGameState: CurrentGameState) {
+    return {
+      gameId: currentGameState.gameId,
+      phase: currentGameState.phase,
+      remainingSeconds: this.getWaitingRemainingSeconds(currentGameState),
+      waitingEndsAt: currentGameState.waitingEndsAt,
+      minPlayers: currentGameState.minPlayers,
+      playerCount: currentGameState.playerCount,
+      spectatorCount: currentGameState.spectatorCount,
+    };
+  }
+
+  async registerConnection() {
+    const currentGameState = await this.ensureCurrentGameState();
+    const assignedRole: ConnectionRole =
+      currentGameState.phase === "in_progress" ? "spectator" : "player";
+    const updatedGameState = await this.updateConnectionCount(currentGameState, assignedRole, 1);
+
+    return {
+      assignedRole,
+      state: this.buildStatePayload(updatedGameState),
+      waiting:
+        updatedGameState.phase === "waiting" ? this.buildWaitingPayload(updatedGameState) : null,
+    };
+  }
+
+  async unregisterConnection(assignedRole?: ConnectionRole) {
+    if (!assignedRole) {
+      return null;
+    }
+
+    const currentGameState = await this.getCurrentGameState();
+
+    if (!currentGameState) {
+      return null;
+    }
+
+    return this.updateConnectionCount(currentGameState, assignedRole, -1);
+  }
+
+  async markTenSecondNoticeSent(currentGameState: CurrentGameState) {
+    const updatedGameState = {
+      ...currentGameState,
+      hasTenSecondNoticeSent: true,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.battleStateRepository.saveCurrentGameState(updatedGameState);
+
+    return updatedGameState;
+  }
+
+  async startCurrentGame(currentGameState: CurrentGameState) {
+    const startedAt = new Date().toISOString();
+    const startedGameState = {
+      ...currentGameState,
+      phase: "in_progress" as const,
+      gameStartedAt: startedAt,
+      hasTenSecondNoticeSent: false,
+      updatedAt: startedAt,
+      waitingEndsAt: null,
+      waitingStartedAt: null,
+    };
+
+    await this.battleStateRepository.saveCurrentGameState(startedGameState);
+
+    return startedGameState;
+  }
+
+  async finishCurrentGame() {
+    const currentGameState = await this.getCurrentGameState();
+
+    if (!currentGameState || currentGameState.phase !== "in_progress") {
+      return null;
+    }
+
+    const finishedAt = new Date().toISOString();
+    const finishedGameState = {
+      ...currentGameState,
+      phase: "finished" as const,
+      gameEndedAt: finishedAt,
+      updatedAt: finishedAt,
+    };
+    const nextWaitingGameState = this.createWaitingGameState(new Date());
+
+    await this.battleStateRepository.saveCurrentGameState(nextWaitingGameState);
+
+    return {
+      finishedGameState,
+      nextWaitingGameState,
+    };
+  }
+
+  private createWaitingGameState(now: Date) {
     const gameId = uuidv7();
+    const waitingStartedAt = now.toISOString();
+    const waitingEndsAt = new Date(now.getTime() + WAITING_DURATION_SECONDS * 1000).toISOString();
 
     const gameState = {
+      createdAt: waitingStartedAt,
+      gameEndedAt: null,
+      gameStartedAt: null,
       gameId,
+      hasTenSecondNoticeSent: false,
       phase: "waiting" as const,
       playerCount: 0,
       minPlayers: 4,
       spectatorCount: 0,
-      startsAt: null,
-      startedAt: null,
-      endedAt: null,
+      updatedAt: waitingStartedAt,
+      waitingEndsAt,
+      waitingStartedAt,
     };
-
-    await this.battleStateRepository.setCurrentGameId(gameId);
-    await this.battleStateRepository.setCurrentGameState(gameId, gameState);
 
     return gameState;
   }
 
-  async getCurrentGameState() {
-    const gameId = (await this.battleStateRepository.getCurrentGameId()) as string;
-    const gameState = await this.battleStateRepository.getCurrentGameState(gameId);
-    return gameState;
+  private async updateConnectionCount(
+    currentGameState: CurrentGameState,
+    assignedRole: ConnectionRole,
+    delta: number,
+  ) {
+    const playerCount =
+      assignedRole === "player"
+        ? Math.max(0, currentGameState.playerCount + delta)
+        : currentGameState.playerCount;
+    const spectatorCount =
+      assignedRole === "spectator"
+        ? Math.max(0, currentGameState.spectatorCount + delta)
+        : currentGameState.spectatorCount;
+    const updatedGameState = {
+      ...currentGameState,
+      playerCount,
+      spectatorCount,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.battleStateRepository.saveCurrentGameState(updatedGameState);
+
+    return updatedGameState;
   }
 }

--- a/apps/backend/src/modules/battle/services/battle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle.service.ts
@@ -26,4 +26,10 @@ export class BattleService {
 
     return gameState;
   }
+
+  async getCurrentGameState() {
+    const gameId = (await this.battleStateRepository.getCurrentGameId()) as string;
+    const gameState = await this.battleStateRepository.getCurrentGameState(gameId);
+    return gameState;
+  }
 }

--- a/apps/backend/src/modules/battle/services/battle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle.service.ts
@@ -1,18 +1,29 @@
 import { Injectable } from "@nestjs/common";
-import type { BattleReadyDto } from "../dto/battle-ready.dto";
+import { v7 as uuidv7 } from "uuid";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { BattleStateRepository } from "../repositories/battle-state.repository";
 
 @Injectable()
 export class BattleService {
-  getWelcomeMessage() {
-    return {
-      message: "Keyboard Warrior Battle Royale server connected",
-    };
-  }
+  constructor(private readonly battleStateRepository: BattleStateRepository) {}
 
-  createReadyConfirmation(payload: BattleReadyDto) {
-    return {
-      nickname: payload.nickname,
-      status: "queued" as const,
+  async startNewGame() {
+    const gameId = uuidv7();
+
+    const gameState = {
+      gameId,
+      phase: "waiting" as const,
+      playerCount: 0,
+      minPlayers: 4,
+      spectatorCount: 0,
+      startsAt: null,
+      startedAt: null,
+      endedAt: null,
     };
+
+    await this.battleStateRepository.setCurrentGameId(gameId);
+    await this.battleStateRepository.setCurrentGameState(gameId, gameState);
+
+    return gameState;
   }
 }

--- a/apps/backend/src/modules/battle/types/current-game-state.ts
+++ b/apps/backend/src/modules/battle/types/current-game-state.ts
@@ -1,0 +1,12 @@
+export type GamePhase = "waiting" | "in_progress" | "finished";
+
+export type CurrentGameState = {
+  gameId: string;
+  phase: GamePhase;
+  minPlayers: number;
+  playerCount: number;
+  spectatorCount: number;
+  startsAt: null | string;
+  startedAt: null | string;
+  endedAt: null | string;
+};

--- a/apps/backend/src/modules/battle/types/current-game-state.ts
+++ b/apps/backend/src/modules/battle/types/current-game-state.ts
@@ -1,12 +1,18 @@
+export type ConnectionRole = "player" | "spectator";
+
 export type GamePhase = "waiting" | "in_progress" | "finished";
 
 export type CurrentGameState = {
   gameId: string;
   phase: GamePhase;
+  createdAt: string;
+  gameEndedAt: null | string;
+  gameStartedAt: null | string;
+  hasTenSecondNoticeSent: boolean;
   minPlayers: number;
   playerCount: number;
   spectatorCount: number;
-  startsAt: null | string;
-  startedAt: null | string;
-  endedAt: null | string;
+  updatedAt: string;
+  waitingEndsAt: null | string;
+  waitingStartedAt: null | string;
 };

--- a/apps/backend/src/modules/game-state/game-state.service.ts
+++ b/apps/backend/src/modules/game-state/game-state.service.ts
@@ -67,7 +67,6 @@ export class GameStateService {
 
   async getCurrentMatchStatus(userId: string) {
     const user = await this.usersService.getMyDashboard(userId);
-    const dashboard = await this.usersService.getMyDashboard(userId);
 
     return {
       match: {
@@ -226,14 +225,6 @@ export class GameStateService {
         accuracy: 0,
       },
     ];
-  }
-
-  private toUserPreview(user: UserProfile) {
-    return {
-      userId: user.id,
-      nickname: user.nickname,
-      avatarUrl: user.avatarUrl,
-    };
   }
 
   private buildUser(id: string, nickname: string, avatarUrl: string): UserProfile {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       socket.io:
         specifier: ^4.8.1
         version: 4.8.3
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.10
@@ -2686,9 +2689,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -5351,7 +5354,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  utils-merge@1.0.1: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2689,6 +2689,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
@@ -5353,6 +5357,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
 
   uuid@14.0.0: {}
 


### PR DESCRIPTION
## 작업 내용
- 샘플코드를 실제 코드로 변경하는 작업을 시작했습니다.
- 사이트 접속을 소캣 접속 시 게임 상태를 확인하고 그것에 따른 메세지를 응답합니다.

## 상세 변경 사항
- battleService에서 게임 상태 생성, 신규 게임 생성, 현재 게임 상태를 불러올 수 있게 했습니다.
- BattleStateRepository를 추가해 레디스에 직접적으로 접근해 정보를 가져오도록 했습니다.

## 관련 이슈
- closes #

## 체크리스트
- [ ] 컨벤션 규칙에 맞게 작성했나요?
- [ ] 빌드가 정상적으로 통과되었나요?
- [ ] 로컬 테스트를 완료헀나요?