### PR TITLE
fix: match 사용자 Redis 키 불일치 수정

### DIFF
--- a/apps/backend/src/modules/match/match.service.ts
+++ b/apps/backend/src/modules/match/match.service.ts
@@ -24,7 +24,7 @@ export class MatchService {
 
     await this.redis.instance.sadd("lobby:players", userId);
     await this.redis.instance.hset(
-      `match:player:${userId}`,
+      `lobby:player:${userId}`,
       "nickname",
       user.nickname,
       "avatarUrl",


### PR DESCRIPTION
## 작업 내용
- `/v1/match/join`과 `/v1/match/users` 간 Redis 키 불일치 문제를 수정했습니다.

## 상세 변경 사항
- `joinGame()`에서 사용자 정보를 저장하는 Redis 키를 조회 로직과 동일한 규칙으로 통일했습니다.
- `/v1/match/users` 호출 시 참가한 사용자가 빈 배열로 조회되던 문제를 해결했습니다.
-  match 관련 사용자 상태 저장 규칙을 `lobby` 기준으로 맞췄습니다.

## 관련 이슈
- closes #

## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?