### PR TITLE
refactor: users DTO를 class 기반으로 분리

### DIFF
--- a/apps/backend/src/modules/users/dto/create-guest-user.dto.ts
+++ b/apps/backend/src/modules/users/dto/create-guest-user.dto.ts
@@ -1,4 +1,11 @@
-export type CreateGuestUserInput = {
-  nickname: string;
-  avatarUrl: string;
-};
+import { IsString, IsUrl, Length } from "class-validator";
+
+export class CreateGuestUserInput {
+  @IsString()
+  @Length(2, 20)
+  nickname!: string;
+
+  @IsString()
+  @IsUrl()
+  avatarUrl!: string;
+}

--- a/apps/backend/src/modules/users/dto/update-my-profile.dto.ts
+++ b/apps/backend/src/modules/users/dto/update-my-profile.dto.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsString, IsUrl, Length } from "class-validator";
+
+export class UpdateMyProfileInput {
+  @IsOptional()
+  @IsString()
+  @Length(2, 20)
+  nickname?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsUrl()
+  avatarUrl?: string;
+}

--- a/apps/backend/src/modules/users/users.controller.ts
+++ b/apps/backend/src/modules/users/users.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Delete, Get, HttpCode, Param, Patch, UseGuards } from
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { AuthUserId } from "../common/auth-user.decorator";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
-import { CreateGuestUserInput } from "./dto/create-guest-user.dto";
+import { UpdateMyProfileInput } from "./dto/update-my-profile.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { UsersService } from "./users.service";
 
@@ -18,7 +18,7 @@ export class UsersController {
 
   @UseGuards(JwtAuthGuard)
   @Patch("me")
-  updateMyProfile(@AuthUserId() userId: string, @Body() input: Partial<CreateGuestUserInput>) {
+  updateMyProfile(@AuthUserId() userId: string, @Body() input: UpdateMyProfileInput) {
     return this.usersService.updateMyProfile(userId, input);
   }
 

--- a/apps/backend/src/modules/users/users.repository.ts
+++ b/apps/backend/src/modules/users/users.repository.ts
@@ -11,6 +11,8 @@ import { CreateGuestUserInput } from "./dto/create-guest-user.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { UpdateDashboardInput } from "./dto/update-dashboard.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { UpdateMyProfileInput } from "./dto/update-my-profile.dto";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { UserRowDto } from "./dto/userRow.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { UserStatsDto } from "./dto/userStats.dto";
@@ -44,7 +46,7 @@ export class UsersRepository {
     return this.toUserProfile(data);
   }
 
-  async updateGuestUser(userId: string, input: Partial<CreateGuestUserInput>) {
+  async updateGuestUser(userId: string, input: UpdateMyProfileInput) {
     await this.findById(userId);
     const updatePayload: Record<string, string> = {};
 

--- a/apps/backend/src/modules/users/users.service.ts
+++ b/apps/backend/src/modules/users/users.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from "@nestjs/common";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { CreateGuestUserInput } from "./dto/create-guest-user.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { UpdateMyProfileInput } from "./dto/update-my-profile.dto";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { UsersRepository } from "./users.repository";
 
 @Injectable()
@@ -16,7 +18,7 @@ export class UsersService {
     return this.usersRepository.findDashboardByUserId(userId);
   }
 
-  async updateMyProfile(userId: string, input: Partial<CreateGuestUserInput>) {
+  async updateMyProfile(userId: string, input: UpdateMyProfileInput) {
     return this.usersRepository.updateGuestUser(userId, input);
   }
 


### PR DESCRIPTION
## 작업 내용
- users DTO를 class 기반으로 정리
- 생성용 DTO와 수정용 DTO를 분리
- users controller/service/repository에서 수정 DTO를 사용하도록 변경

## 상세 변경 사항
- `CreateGuestUserInput`를 class DTO로 변경
- `UpdateMyProfileInput` 추가
- `PATCH /v1/users/me`가 수정 전용 DTO를 사용하도록 반영

## 관련 이슈
- closes #

## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?