### PR TITLE
Feature/api test

### DIFF
--- a/apps/backend/test/auth.spec.ts
+++ b/apps/backend/test/auth.spec.ts
@@ -1,4 +1,4 @@
-import type { INestApplication } from "@nestjs/common";
+import { type INestApplication, UnauthorizedException } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import cookieParser from "cookie-parser";
 import request from "supertest";
@@ -116,7 +116,64 @@ describe("Auth API", () => {
       expect(response.body.message).toBe("리프레시 토큰 쿠키가 없습니다.");
     });
 
-    it("refreshToken 쿠카가 있으면 세션을 갱신하고 새 쿠키를 반환한다", async () => {
+    it("유효하지 않은 refreshToken이면 401을 반환한다", async () => {
+      mockAuthService.refreshSession.mockRejectedValue(
+        new UnauthorizedException({
+          code: "INVALID_REFRESH_TOKEN",
+          message: "리프레스 토큰이 유효하지 않습니다.",
+        }),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post("/v1/auth/refresh")
+        .set("Cookie", ["refreshToken=invalid-refresh-token"])
+        .expect(401);
+
+      expect(mockAuthService.refreshSession).toHaveBeenCalledTimes(1);
+      expect(mockAuthService.refreshSession).toHaveBeenCalledWith("invalid-refresh-token");
+      expect(response.body.code).toBe("INVALID_REFRESH_TOKEN");
+      expect(response.body.message).toBe("리프레스 토큰이 유효하지 않습니다.");
+    });
+
+    it("폐기된 refreshToken이면 401을 반환한다", async () => {
+      mockAuthService.refreshSession.mockRejectedValue(
+        new UnauthorizedException({
+          code: "REFRESH_TOKEN_REVOKED",
+          message: "이미 폐기된 리프레시 토큰입니다.",
+        }),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post("/v1/auth/refresh")
+        .set("Cookie", ["refreshToken=revoked-refresh-token"])
+        .expect(401);
+
+      expect(mockAuthService.refreshSession).toHaveBeenCalledTimes(1);
+      expect(mockAuthService.refreshSession).toHaveBeenCalledWith("revoked-refresh-token");
+      expect(response.body.code).toBe("REFRESH_TOKEN_REVOKED");
+      expect(response.body.message).toBe("이미 폐기된 리프레시 토큰입니다.");
+    });
+
+    it("만료된 refreshToken이면 401을 반환한다", async () => {
+      mockAuthService.refreshSession.mockRejectedValue(
+        new UnauthorizedException({
+          code: "REFRESH_TOKEN_EXPIRED",
+          message: "만료된 리프레시 토큰입니다.",
+        }),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post("/v1/auth/refresh")
+        .set("Cookie", ["refreshToken=expired-refresh-token"])
+        .expect(401);
+
+      expect(mockAuthService.refreshSession).toHaveBeenCalledTimes(1);
+      expect(mockAuthService.refreshSession).toHaveBeenCalledWith("expired-refresh-token");
+      expect(response.body.code).toBe("REFRESH_TOKEN_EXPIRED");
+      expect(response.body.message).toBe("만료된 리프레시 토큰입니다.");
+    });
+
+    it("refreshToken 쿠키가 있으면 세션을 갱신하고 새 쿠키를 반환한다", async () => {
       const session = createMockSession();
       session.tokens.accessToken = "new-access-token-456";
       session.refreshToken = "new-refresh-token-456";
@@ -183,6 +240,15 @@ describe("Auth API", () => {
 
       expect(mockAuthService.logout).toHaveBeenCalledTimes(1);
       expect(mockAuthService.logout).toHaveBeenCalledWith(undefined);
+    });
+
+    it("로그아웃 중 서비스 에러가 발생하면 500을 반환한다", async () => {
+      mockAuthService.logout.mockRejectedValue(new Error("logout failed"));
+
+      await request(app.getHttpServer())
+        .post("/v1/auth/logout")
+        .set("Cookie", ["refreshToken=logout-token-123"])
+        .expect(500);
     });
   });
 });

--- a/apps/backend/test/users.spec.ts
+++ b/apps/backend/test/users.spec.ts
@@ -1,4 +1,9 @@
-import type { CanActivate, ExecutionContext, INestApplication } from "@nestjs/common";
+import {
+  type CanActivate,
+  type ExecutionContext,
+  type INestApplication,
+  ValidationPipe,
+} from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import request from "supertest";
 import { JwtAuthGuard } from "../src/modules/auth/guards/jwt-auth.guard";
@@ -58,6 +63,13 @@ describe("Users API", () => {
       .compile();
 
     app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
     await app.init();
   });
 
@@ -101,6 +113,45 @@ describe("Users API", () => {
       expect(mockUsersService.updateMyProfile).toHaveBeenCalledTimes(1);
       expect(mockUsersService.updateMyProfile).toHaveBeenCalledWith("auth-user-123", input);
       expect(response.body).toEqual(updatedUser);
+    });
+
+    it("nickname이 너무 짧으면 400을 반환한다", async () => {
+      const response = await request(app.getHttpServer())
+        .patch("/v1/users/me")
+        .send({
+          nickname: "a",
+        })
+        .expect(400);
+
+      expect(mockUsersService.updateMyProfile).not.toHaveBeenCalled();
+      expect(response.body.message).toContain(
+        "nickname must be longer than or equal to 2 characters",
+      );
+    });
+
+    it("avatarUrl이 URL 형식이 아니면 400을 반환한다", async () => {
+      const response = await request(app.getHttpServer())
+        .patch("/v1/users/me")
+        .send({
+          avatarUrl: "not-a-url",
+        })
+        .expect(400);
+
+      expect(mockUsersService.updateMyProfile).not.toHaveBeenCalled();
+      expect(response.body.message).toContain("avatarUrl must be a URL address");
+    });
+
+    it("허용되지 않은 필드가 들어오면 400을 반환한다", async () => {
+      const response = await request(app.getHttpServer())
+        .patch("/v1/users/me")
+        .send({
+          nickname: "valid-name",
+          role: "admin",
+        })
+        .expect(400);
+
+      expect(mockUsersService.updateMyProfile).not.toHaveBeenCalled();
+      expect(response.body.message).toContain("property role should not exist");
     });
   });
 

--- a/apps/backend/test/users.spec.ts
+++ b/apps/backend/test/users.spec.ts
@@ -1,7 +1,9 @@
 import {
+  BadRequestException,
   type CanActivate,
   type ExecutionContext,
   type INestApplication,
+  UnauthorizedException,
   ValidationPipe,
 } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
@@ -27,6 +29,12 @@ class MockJwtAuthGuard implements CanActivate {
   }
 }
 
+class RejectJwtAuthGuard implements CanActivate {
+  canActivate(_: ExecutionContext): boolean {
+    throw new UnauthorizedException();
+  }
+}
+
 function createMockUser() {
   return {
     id: "user-123",
@@ -47,6 +55,7 @@ function createMockDashboard() {
 
 describe("Users API", () => {
   let app: INestApplication;
+  let unauthorizedApp: INestApplication;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -71,6 +80,29 @@ describe("Users API", () => {
       }),
     );
     await app.init();
+
+    const unauthorizedModuleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useClass(RejectJwtAuthGuard)
+      .compile();
+
+    unauthorizedApp = unauthorizedModuleRef.createNestApplication();
+    unauthorizedApp.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await unauthorizedApp.init();
   });
 
   beforeEach(() => {
@@ -79,6 +111,7 @@ describe("Users API", () => {
 
   afterAll(async () => {
     await app.close();
+    await unauthorizedApp.close();
   });
 
   describe("GET /v1/users/me", () => {
@@ -141,6 +174,20 @@ describe("Users API", () => {
       expect(response.body.message).toContain("avatarUrl must be a URL address");
     });
 
+    it("nickname이 20자를 초과하면 400을 반환한다", async () => {
+      const response = await request(app.getHttpServer())
+        .patch("/v1/users/me")
+        .send({
+          nickname: "this-nickname-is-way-too-long",
+        })
+        .expect(400);
+
+      expect(mockUsersService.updateMyProfile).not.toHaveBeenCalled();
+      expect(response.body.message).toContain(
+        "nickname must be shorter than or equal to 20 characters",
+      );
+    });
+
     it("허용되지 않은 필드가 들어오면 400을 반환한다", async () => {
       const response = await request(app.getHttpServer())
         .patch("/v1/users/me")
@@ -152,6 +199,21 @@ describe("Users API", () => {
 
       expect(mockUsersService.updateMyProfile).not.toHaveBeenCalled();
       expect(response.body.message).toContain("property role should not exist");
+    });
+
+    it("수정할 필드가 없으면 400을 반환한다", async () => {
+      mockUsersService.updateMyProfile.mockRejectedValue(
+        new BadRequestException("수정할 항목이 없습니다."),
+      );
+
+      const response = await request(app.getHttpServer())
+        .patch("/v1/users/me")
+        .send({})
+        .expect(400);
+
+      expect(mockUsersService.updateMyProfile).toHaveBeenCalledTimes(1);
+      expect(mockUsersService.updateMyProfile).toHaveBeenCalledWith("auth-user-123", {});
+      expect(response.body.message).toBe("수정할 항목이 없습니다.");
     });
   });
 
@@ -205,6 +267,31 @@ describe("Users API", () => {
       expect(mockUsersService.getMyDashboard).toHaveBeenCalledTimes(1);
       expect(mockUsersService.getMyDashboard).toHaveBeenCalledWith("user-999");
       expect(response.body).toEqual(dashboard);
+    });
+  });
+
+  describe("인증 실패", () => {
+    it("GET /v1/users/me 요청이 인증되지 않으면 401을 반환한다", async () => {
+      await request(unauthorizedApp.getHttpServer()).get("/v1/users/me").expect(401);
+
+      expect(mockUsersService.getMyProfile).not.toHaveBeenCalled();
+    });
+
+    it("PATCH /v1/users/me 요청이 인증되지 않으면 401을 반환한다", async () => {
+      await request(unauthorizedApp.getHttpServer())
+        .patch("/v1/users/me")
+        .send({
+          nickname: "updated-user",
+        })
+        .expect(401);
+
+      expect(mockUsersService.updateMyProfile).not.toHaveBeenCalled();
+    });
+
+    it("DELETE /v1/users/me 요청이 인증되지 않으면 401을 반환한다", async () => {
+      await request(unauthorizedApp.getHttpServer()).delete("/v1/users/me").expect(401);
+
+      expect(mockUsersService.deleteMyProfile).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## 작업 내용
- auth API 테스트 보강
- users API 테스트 보강
- users 입력 검증 실패 케이스 테스트 추가
- users 인증 실패 케이스 테스트 추가

## 상세 변경 사항
- `auth.spec.ts`
  - refresh 실패 케이스 추가
    - 잘못된 토큰
    - 폐기된 토큰
    - 만료된 토큰
  - logout 서비스 에러 시 `500` 응답 테스트 추가

- `users.spec.ts`
  - `ValidationPipe` 적용
  - 프로필 수정 validation 실패 테스트 추가
    - nickname 최소 길이
    - nickname 최대 길이
    - avatarUrl 형식 오류
    - 허용되지 않은 필드
  - 수정할 필드가 없을 때 `400` 테스트 추가
  - 인증 실패 시 `401` 테스트 추가

## 관련 이슈
- closes #24 

## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?