### PR TITLE
소캣 연결 시 플레이어 역할 배정

### DIFF
--- a/apps/backend/src/common/constants/socket-events.ts
+++ b/apps/backend/src/common/constants/socket-events.ts
@@ -1,5 +1,6 @@
 export const SOCKET_EVENTS = {
   BATTLE_COUNTDOWN: "battle:countdown",
+  BATTLE_ELIMINATED: "battle:eliminated",
   BATTLE_FINISHED: "battle:finished",
   BATTLE_JOIN: "battle:join",
   BATTLE_READY: "battle:ready",

--- a/apps/backend/src/modules/battle/gateways/battle.gateway.ts
+++ b/apps/backend/src/modules/battle/gateways/battle.gateway.ts
@@ -2,6 +2,8 @@ import {
   ConnectedSocket,
   MessageBody,
   type OnGatewayConnection,
+  type OnGatewayDisconnect,
+  type OnGatewayInit,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
@@ -11,31 +13,119 @@ import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
 import type { BattleReadyDto } from "../dto/battle-ready.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { BattleService } from "../services/battle.service";
+// biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
+import { BattleBroadcastService } from "../services/battle-broadcast.service";
 
 @WebSocketGateway({
+  namespace: "/battle",
   cors: {
     origin: "*",
   },
 })
-export class BattleGateway implements OnGatewayConnection {
-  constructor(private readonly battleService: BattleService) {}
+export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit {
+  constructor(
+    private readonly battleService: BattleService,
+    private readonly battleBroadcastService: BattleBroadcastService,
+  ) {}
 
   @WebSocketServer()
   server!: Server;
 
-  handleConnection(client: Socket) {
+  afterInit(server: Server) {
+    this.battleBroadcastService.setServer(server);
+  }
+
+  async handleConnection(client: Socket) {
+    const connection = await this.battleService.registerConnection();
+    const roomName = this.getBattleRoomName(connection.state.gameId);
+
+    client.data.assignedRole = connection.assignedRole;
+    client.data.gameId = connection.state.gameId;
+
+    client.join(roomName);
     client.emit(SOCKET_EVENTS.BATTLE_WELCOME, this.battleService.getWelcomeMessage());
+    client.emit(SOCKET_EVENTS.BATTLE_STATE, connection.state);
+
+    if (connection.waiting) {
+      client.emit(SOCKET_EVENTS.BATTLE_WAITING, connection.waiting);
+      client.broadcast.to(roomName).emit(SOCKET_EVENTS.BATTLE_WAITING, connection.waiting);
+    } else {
+      client.broadcast.to(roomName).emit(SOCKET_EVENTS.BATTLE_STATE, connection.state);
+    }
+  }
+
+  async handleDisconnect(client: Socket) {
+    const assignedRole = this.getAssignedRole(client);
+    const gameId = this.getGameId(client);
+    const updatedGameState = await this.battleService.unregisterConnection({
+      assignedRole,
+      gameId,
+    });
+
+    if (!updatedGameState) {
+      return;
+    }
+
+    const roomName = this.getBattleRoomName(updatedGameState.gameId);
+
+    if (assignedRole === "player" && updatedGameState.phase === "in_progress") {
+      this.server.to(roomName).emit(SOCKET_EVENTS.BATTLE_ELIMINATED, {
+        gameId: updatedGameState.gameId,
+        reason: "disconnected",
+        socketId: client.id,
+        ...this.getUserIdPayload(client),
+      });
+    }
+
+    if (updatedGameState.phase === "waiting") {
+      this.server
+        .to(roomName)
+        .emit(
+          SOCKET_EVENTS.BATTLE_WAITING,
+          this.battleService.buildWaitingPayload(updatedGameState),
+        );
+      return;
+    }
+
+    this.server
+      .to(roomName)
+      .emit(SOCKET_EVENTS.BATTLE_STATE, this.battleService.buildStatePayload(updatedGameState));
   }
 
   @SubscribeMessage(SOCKET_EVENTS.BATTLE_READY)
   handleReady(@MessageBody() payload: BattleReadyDto, @ConnectedSocket() client: Socket) {
     const confirmed = this.battleService.createReadyConfirmation(payload);
+    const gameId = this.getGameId(client);
 
-    client.broadcast.emit(SOCKET_EVENTS.BATTLE_PLAYER_READY, payload);
+    if (gameId) {
+      client.broadcast
+        .to(this.getBattleRoomName(gameId))
+        .emit(SOCKET_EVENTS.BATTLE_PLAYER_READY, payload);
+    } else {
+      client.broadcast.emit(SOCKET_EVENTS.BATTLE_PLAYER_READY, payload);
+    }
 
     return {
       event: SOCKET_EVENTS.BATTLE_READY_CONFIRMED,
       data: confirmed,
     };
+  }
+
+  private getAssignedRole(client: Socket) {
+    const assignedRole = client.data.assignedRole;
+
+    return assignedRole === "player" || assignedRole === "spectator" ? assignedRole : undefined;
+  }
+
+  private getBattleRoomName(gameId: string) {
+    return `battle:${gameId}`;
+  }
+
+  private getGameId(client: Socket) {
+    return typeof client.data.gameId === "string" ? client.data.gameId : undefined;
+  }
+
+  private getUserIdPayload(client: Socket) {
+    return typeof client.data.userId === "string" ? { userId: client.data.userId } : {};
   }
 }

--- a/apps/backend/src/modules/battle/services/battle-cycle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle-cycle.service.ts
@@ -8,7 +8,6 @@ import { BattleService } from "./battle.service";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { BattleBroadcastService } from "./battle-broadcast.service";
 
-const TEN_SECOND_NOTICE_THRESHOLD = 10;
 const TIMER_INTERVAL_MILLISECONDS = 1000;
 const TIMER_LOCK_TTL_SECONDS = 1;
 
@@ -107,22 +106,6 @@ export class BattleCycleService implements OnModuleDestroy, OnModuleInit {
       );
 
       return;
-    }
-
-    if (
-      remainingSeconds <= TEN_SECOND_NOTICE_THRESHOLD &&
-      !currentGameState.hasTenSecondNoticeSent
-    ) {
-      const updatedGameState = await this.battleService.markTenSecondNoticeSent(currentGameState);
-
-      this.battleBroadcastService.emitToAll(
-        SOCKET_EVENTS.BATTLE_COUNTDOWN,
-        this.battleService.buildWaitingPayload(updatedGameState),
-      );
-      this.battleBroadcastService.emitToAll(
-        SOCKET_EVENTS.BATTLE_STATE,
-        this.battleService.buildStatePayload(updatedGameState),
-      );
     }
 
     this.battleBroadcastService.emitToAll(

--- a/apps/backend/src/modules/battle/services/battle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle.service.ts
@@ -63,7 +63,14 @@ export class BattleService {
   buildStatePayload(currentGameState: CurrentGameState) {
     return {
       gameId: currentGameState.gameId,
-      prompt: currentGameState.prompt,
+      prompt:
+        currentGameState.phase === "waiting"
+          ? {
+              contentLength: currentGameState.prompt.contentLength,
+              id: currentGameState.prompt.id,
+              title: currentGameState.prompt.title,
+            }
+          : currentGameState.prompt,
       phase: currentGameState.phase,
       minPlayers: currentGameState.minPlayers,
       playerCount: currentGameState.playerCount,
@@ -105,7 +112,9 @@ export class BattleService {
     };
   }
 
-  async unregisterConnection(assignedRole?: ConnectionRole) {
+  async unregisterConnection(input: { assignedRole?: ConnectionRole; gameId?: string } = {}) {
+    const { assignedRole, gameId } = input;
+
     if (!assignedRole) {
       return null;
     }
@@ -113,6 +122,10 @@ export class BattleService {
     const currentGameState = await this.getCurrentGameState();
 
     if (!currentGameState) {
+      return null;
+    }
+
+    if (gameId && currentGameState.gameId !== gameId) {
       return null;
     }
 

--- a/apps/backend/test/battle.gateway.spec.ts
+++ b/apps/backend/test/battle.gateway.spec.ts
@@ -1,0 +1,266 @@
+import type { Server, Socket } from "socket.io";
+
+jest.mock("uuid", () => ({
+  v7: jest.fn(() => "uuid-v7"),
+}));
+
+import { SOCKET_EVENTS } from "../src/common/constants/socket-events";
+import { BattleGateway } from "../src/modules/battle/gateways/battle.gateway";
+import type { BattleStateRepository } from "../src/modules/battle/repositories/battle-state.repository";
+import type { PromptRepository } from "../src/modules/battle/repositories/prompt.repository";
+import { BattleService } from "../src/modules/battle/services/battle.service";
+import type { BattleBroadcastService } from "../src/modules/battle/services/battle-broadcast.service";
+import type { CurrentGameState } from "../src/modules/battle/types/current-game-state";
+
+const prompt = {
+  content: "hello battle",
+  contentLength: 12,
+  id: 1,
+  slug: "hello-battle",
+  title: "Hello Battle",
+};
+
+function createGameState(overrides: Partial<CurrentGameState> = {}): CurrentGameState {
+  return {
+    createdAt: "2026-05-06T00:00:00.000Z",
+    gameEndedAt: null,
+    gameId: "game-1",
+    gameStartedAt: null,
+    hasTenSecondNoticeSent: false,
+    minPlayers: 4,
+    phase: "waiting",
+    playerCount: 1,
+    prompt,
+    spectatorCount: 0,
+    updatedAt: "2026-05-06T00:00:00.000Z",
+    waitingEndsAt: "2026-05-06T00:15:00.000Z",
+    waitingStartedAt: "2026-05-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createSocket() {
+  const broadcastEmit = jest.fn();
+  const broadcastTo = jest.fn(() => ({ emit: broadcastEmit }));
+  const emit = jest.fn();
+  const join = jest.fn();
+  const socket = {
+    broadcast: {
+      emit: broadcastEmit,
+      to: broadcastTo,
+    },
+    data: {},
+    emit,
+    id: "socket-1",
+    join,
+  } as unknown as Socket;
+
+  return { broadcastEmit, broadcastTo, emit, join, socket };
+}
+
+function createServer() {
+  const emit = jest.fn();
+  const to = jest.fn(() => ({ emit }));
+  const server = { to } as unknown as Server;
+
+  return { emit, server, to };
+}
+
+describe("BattleGateway", () => {
+  it("registers the Socket.IO server for background cycle broadcasts", () => {
+    const battleService = {} as BattleService;
+    const setServer = jest.fn();
+    const battleBroadcastService = { setServer } as unknown as BattleBroadcastService;
+    const server = {} as Server;
+    const gateway = new BattleGateway(battleService, battleBroadcastService);
+
+    gateway.afterInit(server);
+
+    expect(setServer).toHaveBeenCalledWith(server);
+  });
+
+  it("sends the current state immediately when a player connects during waiting", async () => {
+    const state = createGameState({ playerCount: 2 });
+    const waiting = {
+      gameId: state.gameId,
+      minPlayers: state.minPlayers,
+      phase: state.phase,
+      playerCount: state.playerCount,
+      prompt: {
+        contentLength: prompt.contentLength,
+        id: prompt.id,
+        title: prompt.title,
+      },
+      remainingSeconds: 900,
+      spectatorCount: state.spectatorCount,
+      waitingEndsAt: state.waitingEndsAt,
+    };
+    const registerConnection = jest.fn().mockResolvedValue({
+      assignedRole: "player",
+      state,
+      waiting,
+    });
+    const getWelcomeMessage = jest.fn(() => ({ message: "connected" }));
+    const battleService = {
+      getWelcomeMessage,
+      registerConnection,
+    } as unknown as BattleService;
+    const gateway = new BattleGateway(battleService, {} as BattleBroadcastService);
+    const { broadcastEmit, broadcastTo, emit, join, socket } = createSocket();
+
+    await gateway.handleConnection(socket);
+
+    expect(registerConnection).toHaveBeenCalledWith();
+    expect(socket.data).toMatchObject({ assignedRole: "player", gameId: state.gameId });
+    expect(join).toHaveBeenCalledWith("battle:game-1");
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_WELCOME, { message: "connected" });
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_STATE, state);
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_WAITING, waiting);
+    expect(broadcastTo).toHaveBeenCalledWith("battle:game-1");
+    expect(broadcastEmit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_WAITING, waiting);
+  });
+
+  it("updates the room when a waiting player disconnects", async () => {
+    const updatedGameState = createGameState({ playerCount: 1 });
+    const waiting = {
+      gameId: updatedGameState.gameId,
+      minPlayers: updatedGameState.minPlayers,
+      phase: updatedGameState.phase,
+      playerCount: updatedGameState.playerCount,
+      prompt: {
+        contentLength: prompt.contentLength,
+        id: prompt.id,
+        title: prompt.title,
+      },
+      remainingSeconds: 899,
+      spectatorCount: updatedGameState.spectatorCount,
+      waitingEndsAt: updatedGameState.waitingEndsAt,
+    };
+    const unregisterConnection = jest.fn().mockResolvedValue(updatedGameState);
+    const buildWaitingPayload = jest.fn(() => waiting);
+    const battleService = {
+      buildWaitingPayload,
+      unregisterConnection,
+    } as unknown as BattleService;
+    const gateway = new BattleGateway(battleService, {} as BattleBroadcastService);
+    const { emit, server, to } = createServer();
+    const { socket } = createSocket();
+    gateway.server = server;
+    socket.data.assignedRole = "player";
+    socket.data.gameId = "game-1";
+
+    await gateway.handleDisconnect(socket);
+
+    expect(unregisterConnection).toHaveBeenCalledWith({
+      assignedRole: "player",
+      gameId: "game-1",
+    });
+    expect(to).toHaveBeenCalledWith("battle:game-1");
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_WAITING, waiting);
+  });
+
+  it("notifies the room when an active player disconnects during a game", async () => {
+    const updatedGameState = createGameState({
+      gameStartedAt: "2026-05-06T00:15:00.000Z",
+      phase: "in_progress",
+      playerCount: 3,
+      waitingEndsAt: null,
+      waitingStartedAt: null,
+    });
+    const statePayload = { ...updatedGameState };
+    const unregisterConnection = jest.fn().mockResolvedValue(updatedGameState);
+    const buildStatePayload = jest.fn(() => statePayload);
+    const battleService = {
+      buildStatePayload,
+      unregisterConnection,
+    } as unknown as BattleService;
+    const gateway = new BattleGateway(battleService, {} as BattleBroadcastService);
+    const { emit, server } = createServer();
+    const { socket } = createSocket();
+    gateway.server = server;
+    socket.data.assignedRole = "player";
+    socket.data.gameId = "game-1";
+    socket.data.userId = "user-1";
+
+    await gateway.handleDisconnect(socket);
+
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_ELIMINATED, {
+      gameId: "game-1",
+      reason: "disconnected",
+      socketId: "socket-1",
+      userId: "user-1",
+    });
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_STATE, statePayload);
+  });
+
+  it("scopes ready broadcasts to the active game room", () => {
+    const confirmed = { nickname: "Jay", status: "queued" as const };
+    const createReadyConfirmation = jest.fn(() => confirmed);
+    const battleService = {
+      createReadyConfirmation,
+    } as unknown as BattleService;
+    const gateway = new BattleGateway(battleService, {} as BattleBroadcastService);
+    const { broadcastEmit, broadcastTo, socket } = createSocket();
+    socket.data.gameId = "game-1";
+
+    const result = gateway.handleReady({ nickname: "Jay" }, socket);
+
+    expect(broadcastTo).toHaveBeenCalledWith("battle:game-1");
+    expect(broadcastEmit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_PLAYER_READY, {
+      nickname: "Jay",
+    });
+    expect(result).toEqual({
+      data: confirmed,
+      event: SOCKET_EVENTS.BATTLE_READY_CONFIRMED,
+    });
+  });
+});
+
+describe("BattleService socket payloads", () => {
+  it("does not expose prompt content while the game is waiting", () => {
+    const service = new BattleService({} as BattleStateRepository, {} as PromptRepository);
+
+    const payload = service.buildStatePayload(createGameState());
+
+    expect(payload.prompt).toEqual({
+      contentLength: prompt.contentLength,
+      id: prompt.id,
+      title: prompt.title,
+    });
+  });
+
+  it("exposes prompt content after the game starts", () => {
+    const service = new BattleService({} as BattleStateRepository, {} as PromptRepository);
+
+    const payload = service.buildStatePayload(
+      createGameState({
+        gameStartedAt: "2026-05-06T00:15:00.000Z",
+        phase: "in_progress",
+        waitingEndsAt: null,
+        waitingStartedAt: null,
+      }),
+    );
+
+    expect(payload.prompt).toEqual(prompt);
+  });
+
+  it("does not decrement the next game when an old socket disconnects late", async () => {
+    const getCurrentGameState = jest.fn().mockResolvedValue(createGameState({ gameId: "game-2" }));
+    const saveCurrentGameState = jest.fn();
+    const service = new BattleService(
+      {
+        getCurrentGameState,
+        saveCurrentGameState,
+      } as unknown as BattleStateRepository,
+      {} as PromptRepository,
+    );
+
+    const result = await service.unregisterConnection({
+      assignedRole: "player",
+      gameId: "game-1",
+    });
+
+    expect(result).toBeNull();
+    expect(saveCurrentGameState).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 작업 내용
- 소캣 연결시 플레이어 역할 배정

## 각 페이즈 별 규칙
### waiting
- 사용자가 접속하면 player로 참가
- 재접속 가능
- 서버가 1초마다 남은 시간 전송
- 다른 사용자가 접속하면 참가자 수 갱신
- 시간이 끝났고 최소 인원 충족이면 in_progress로 전환
- 최소 인원 미충족이면 waiting 타이머 재시작
### in_progress
- 새 접속자는 spectator
- 관람자는 현재 게임 진행 상황 조회 가능
- player가 연결 끊기면 탈락
- 입력 이벤트 처리
- 모든 플레이어 탈락 또는 조건 충족 시 finished로 전환
### finished
- 결과 전송
- 짧은 결과 표시 시간 후 다음 waiting 게임 생성
- 또는 즉시 다음 waiting으로 넘어감


## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?