### PR TITLE
플레이서 타자 검증 및 사용자 소캣 인증 추가

### DIFF
--- a/apps/backend/src/common/constants/socket-events.ts
+++ b/apps/backend/src/common/constants/socket-events.ts
@@ -1,8 +1,12 @@
 export const SOCKET_EVENTS = {
   BATTLE_COUNTDOWN: "battle:countdown",
   BATTLE_ELIMINATED: "battle:eliminated",
+  BATTLE_ERROR: "battle:error",
   BATTLE_FINISHED: "battle:finished",
+  BATTLE_INPUT: "battle:input",
+  BATTLE_INPUT_RESULT: "battle:input-result",
   BATTLE_JOIN: "battle:join",
+  BATTLE_PROGRESS: "battle:progress",
   BATTLE_READY: "battle:ready",
   BATTLE_READY_CONFIRMED: "battle:ready-confirmed",
   BATTLE_PLAYER_READY: "battle:player-ready",

--- a/apps/backend/src/modules/battle/constants/battle-redis-keys.ts
+++ b/apps/backend/src/modules/battle/constants/battle-redis-keys.ts
@@ -1,0 +1,9 @@
+export const BATTLE_SOCKET_AUTH_TOKEN_TTL_SECONDS = 60 * 60;
+
+export function getBattleActiveConnectionKey(gameId: string, participantId: string) {
+  return `battle:game:${gameId}:active-connection:${participantId}`;
+}
+
+export function getBattleSocketAuthTokenKey(token: string) {
+  return `battle:socket-auth-token:${token}`;
+}

--- a/apps/backend/src/modules/battle/dto/battle-input.dto.ts
+++ b/apps/backend/src/modules/battle/dto/battle-input.dto.ts
@@ -1,0 +1,5 @@
+export type BattleInputDto = {
+  cursorPosition?: number | undefined;
+  gameId: string;
+  typedText: string;
+};

--- a/apps/backend/src/modules/battle/gateways/battle.gateway.ts
+++ b/apps/backend/src/modules/battle/gateways/battle.gateway.ts
@@ -10,6 +10,7 @@ import {
 } from "@nestjs/websockets";
 import type { Server, Socket } from "socket.io";
 import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
+import type { BattleInputDto } from "../dto/battle-input.dto";
 import type { BattleReadyDto } from "../dto/battle-ready.dto";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { BattleService } from "../services/battle.service";
@@ -36,11 +37,27 @@ export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, 
   }
 
   async handleConnection(client: Socket) {
-    const connection = await this.battleService.registerConnection();
+    const session = await this.battleService.verifySocketAuthToken(this.getSocketAuthToken(client));
+
+    if (!session) {
+      client.emit(SOCKET_EVENTS.BATTLE_ERROR, {
+        code: "INVALID_SOCKET_AUTH_TOKEN",
+        message: "소켓 인증 토큰이 유효하지 않습니다.",
+      });
+      client.disconnect(true);
+      return;
+    }
+
+    const connection = await this.battleService.registerConnection({
+      participantId: session.userId,
+      socketId: client.id,
+    });
     const roomName = this.getBattleRoomName(connection.state.gameId);
 
     client.data.assignedRole = connection.assignedRole;
     client.data.gameId = connection.state.gameId;
+    client.data.participantId = session.userId;
+    client.data.userId = session.userId;
 
     client.join(roomName);
     client.emit(SOCKET_EVENTS.BATTLE_WELCOME, this.battleService.getWelcomeMessage());
@@ -56,10 +73,16 @@ export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, 
 
   async handleDisconnect(client: Socket) {
     const assignedRole = this.getAssignedRole(client);
-    const gameId = this.getGameId(client);
+
+    if (!assignedRole) {
+      return;
+    }
+
     const updatedGameState = await this.battleService.unregisterConnection({
       assignedRole,
-      gameId,
+      gameId: this.getGameId(client),
+      participantId: this.getParticipantId(client),
+      socketId: client.id,
     });
 
     if (!updatedGameState) {
@@ -90,6 +113,42 @@ export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, 
     this.server
       .to(roomName)
       .emit(SOCKET_EVENTS.BATTLE_STATE, this.battleService.buildStatePayload(updatedGameState));
+  }
+
+  @SubscribeMessage(SOCKET_EVENTS.BATTLE_INPUT)
+  async handleInput(@MessageBody() payload: BattleInputDto, @ConnectedSocket() client: Socket) {
+    const result = await this.battleService.validateInput({
+      assignedRole: this.getAssignedRole(client),
+      cursorPosition: payload.cursorPosition,
+      gameId: payload.gameId,
+      participantId: this.getParticipantId(client),
+      socketId: client.id,
+      typedText: payload.typedText,
+    });
+
+    if (result.ok) {
+      const roomName = this.getBattleRoomName(result.data.gameId);
+
+      this.server.to(roomName).emit(SOCKET_EVENTS.BATTLE_PROGRESS, {
+        gameId: result.data.gameId,
+        participant: result.data.participant,
+      });
+
+      if (result.data.isEliminated) {
+        this.server.to(roomName).emit(SOCKET_EVENTS.BATTLE_ELIMINATED, {
+          gameId: result.data.gameId,
+          participantId: result.data.participant.participantId,
+          reason: "typo",
+          socketId: result.data.participant.socketId,
+          userId: result.data.participant.participantId,
+        });
+      }
+    }
+
+    return {
+      event: SOCKET_EVENTS.BATTLE_INPUT_RESULT,
+      data: result,
+    };
   }
 
   @SubscribeMessage(SOCKET_EVENTS.BATTLE_READY)
@@ -127,5 +186,16 @@ export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, 
 
   private getUserIdPayload(client: Socket) {
     return typeof client.data.userId === "string" ? { userId: client.data.userId } : {};
+  }
+
+  private getParticipantId(client: Socket) {
+    return typeof client.data.participantId === "string" ? client.data.participantId : client.id;
+  }
+
+  private getSocketAuthToken(client: Socket) {
+    const auth = client.handshake.auth as Record<string, unknown> | undefined;
+    const token = auth?.token ?? auth?.socketAuthToken;
+
+    return typeof token === "string" ? token : undefined;
   }
 }

--- a/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
+++ b/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
@@ -1,6 +1,16 @@
 import { Injectable } from "@nestjs/common";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { RedisService } from "../../storage/redis/redis.service";
+import {
+  BATTLE_SOCKET_AUTH_TOKEN_TTL_SECONDS,
+  getBattleActiveConnectionKey,
+  getBattleSocketAuthTokenKey,
+} from "../constants/battle-redis-keys";
+import type { BattleParticipantState } from "../types/battle-participant-state";
+import type {
+  BattleActiveConnection,
+  BattleSocketAuthSession,
+} from "../types/battle-socket-session";
 import type { CurrentGameState } from "../types/current-game-state";
 
 const CURRENT_GAME_ID_KEY = "battle:current-game-id";
@@ -57,5 +67,64 @@ export class BattleStateRepository {
     }
 
     return JSON.parse(value) as CurrentGameState;
+  }
+
+  async getActiveConnection(gameId: string, participantId: string) {
+    const value = await this.redisService.instance.get(
+      getBattleActiveConnectionKey(gameId, participantId),
+    );
+
+    if (!value) {
+      return null;
+    }
+
+    return JSON.parse(value) as BattleActiveConnection;
+  }
+
+  async getParticipantState(gameId: string, participantId: string) {
+    const value = await this.redisService.instance.get(
+      `battle:game:${gameId}:participant:${participantId}`,
+    );
+
+    if (!value) {
+      return null;
+    }
+
+    return JSON.parse(value) as BattleParticipantState;
+  }
+
+  async saveParticipantState(participantState: BattleParticipantState) {
+    await this.redisService.instance.set(
+      `battle:game:${participantState.gameId}:participant:${participantState.participantId}`,
+      JSON.stringify(participantState),
+    );
+  }
+
+  async deleteActiveConnection(gameId: string, participantId: string) {
+    await this.redisService.instance.del(getBattleActiveConnectionKey(gameId, participantId));
+  }
+
+  async getSocketAuthSession(token: string) {
+    const value = await this.redisService.instance.get(getBattleSocketAuthTokenKey(token));
+
+    if (!value) {
+      return null;
+    }
+
+    return JSON.parse(value) as BattleSocketAuthSession;
+  }
+
+  async refreshSocketAuthSession(token: string) {
+    await this.redisService.instance.expire(
+      getBattleSocketAuthTokenKey(token),
+      BATTLE_SOCKET_AUTH_TOKEN_TTL_SECONDS,
+    );
+  }
+
+  async saveActiveConnection(activeConnection: BattleActiveConnection) {
+    await this.redisService.instance.set(
+      getBattleActiveConnectionKey(activeConnection.gameId, activeConnection.participantId),
+      JSON.stringify(activeConnection),
+    );
   }
 }

--- a/apps/backend/src/modules/battle/services/battle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle.service.ts
@@ -5,9 +5,58 @@ import type { BattleReadyDto } from "../dto/battle-ready.dto";
 import { BattleStateRepository } from "../repositories/battle-state.repository";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { PromptRepository } from "../repositories/prompt.repository";
+import type { BattleParticipantState } from "../types/battle-participant-state";
 import type { ConnectionRole, CurrentGameState } from "../types/current-game-state";
 
 const WAITING_DURATION_SECONDS = 15 * 60;
+const DEFAULT_PLAYER_LIFE = 3;
+
+type BattleInputValidationInput = {
+  assignedRole?: ConnectionRole | undefined;
+  cursorPosition?: number | undefined;
+  gameId: string;
+  participantId: string;
+  socketId: string;
+  typedText: string;
+};
+
+type BattleConnectionInput = {
+  participantId: string;
+  socketId: string;
+};
+
+type BattleDisconnectionInput = {
+  assignedRole?: ConnectionRole | undefined;
+  gameId?: string | undefined;
+  participantId?: string | undefined;
+  socketId?: string | undefined;
+};
+
+type BattleInputRejectedResult = {
+  code: string;
+  message: string;
+  ok: false;
+};
+
+type BattleInputAcceptedResult = {
+  data: {
+    acceptedLength: number;
+    accuracy: number;
+    expectedLength: number;
+    gameId: string;
+    isEliminated: boolean;
+    isFinished: boolean;
+    isTypo: boolean;
+    life: number;
+    participant: BattleParticipantState;
+    progressPercent: number;
+    typedLength: number;
+    typoIndex: null | number;
+  };
+  ok: true;
+};
+
+export type BattleInputValidationResult = BattleInputAcceptedResult | BattleInputRejectedResult;
 
 @Injectable()
 export class BattleService {
@@ -44,6 +93,22 @@ export class BattleService {
 
   async getCurrentGameState() {
     return this.battleStateRepository.getCurrentGameState();
+  }
+
+  async verifySocketAuthToken(token?: string) {
+    if (!token) {
+      return null;
+    }
+
+    const session = await this.battleStateRepository.getSocketAuthSession(token);
+
+    if (!session?.userId) {
+      return null;
+    }
+
+    await this.battleStateRepository.refreshSocketAuthSession(token);
+
+    return session;
   }
 
   getWaitingRemainingSeconds(currentGameState: CurrentGameState) {
@@ -98,11 +163,38 @@ export class BattleService {
     };
   }
 
-  async registerConnection() {
+  async registerConnection(input: BattleConnectionInput) {
     const currentGameState = await this.ensureCurrentGameState();
+    const activeConnection = await this.battleStateRepository.getActiveConnection(
+      currentGameState.gameId,
+      input.participantId,
+    );
+
+    if (activeConnection) {
+      const refreshedConnection = {
+        ...activeConnection,
+        socketId: input.socketId,
+      };
+
+      await this.battleStateRepository.saveActiveConnection(refreshedConnection);
+
+      return {
+        assignedRole: refreshedConnection.assignedRole,
+        state: this.buildStatePayload(currentGameState),
+        waiting:
+          currentGameState.phase === "waiting" ? this.buildWaitingPayload(currentGameState) : null,
+      };
+    }
+
     const assignedRole: ConnectionRole =
       currentGameState.phase === "in_progress" ? "spectator" : "player";
     const updatedGameState = await this.updateConnectionCount(currentGameState, assignedRole, 1);
+    await this.battleStateRepository.saveActiveConnection({
+      assignedRole,
+      gameId: updatedGameState.gameId,
+      participantId: input.participantId,
+      socketId: input.socketId,
+    });
 
     return {
       assignedRole,
@@ -112,10 +204,8 @@ export class BattleService {
     };
   }
 
-  async unregisterConnection(input: { assignedRole?: ConnectionRole; gameId?: string } = {}) {
-    const { assignedRole, gameId } = input;
-
-    if (!assignedRole) {
+  async unregisterConnection(input: BattleDisconnectionInput = {}) {
+    if (!input.assignedRole) {
       return null;
     }
 
@@ -125,11 +215,95 @@ export class BattleService {
       return null;
     }
 
-    if (gameId && currentGameState.gameId !== gameId) {
+    if (input.gameId && input.gameId !== currentGameState.gameId) {
       return null;
     }
 
+    let assignedRole = input.assignedRole;
+
+    if (input.participantId && input.socketId) {
+      const activeConnection = await this.battleStateRepository.getActiveConnection(
+        currentGameState.gameId,
+        input.participantId,
+      );
+
+      if (!activeConnection || activeConnection.socketId !== input.socketId) {
+        return null;
+      }
+
+      assignedRole = activeConnection.assignedRole;
+      await this.battleStateRepository.deleteActiveConnection(
+        currentGameState.gameId,
+        input.participantId,
+      );
+    }
+
     return this.updateConnectionCount(currentGameState, assignedRole, -1);
+  }
+
+  async validateInput(input: BattleInputValidationInput): Promise<BattleInputValidationResult> {
+    if (input.assignedRole !== "player") {
+      return this.rejectInput("NOT_PLAYER", "플레이어만 입력할 수 있습니다.");
+    }
+
+    const currentGameState = await this.getCurrentGameState();
+
+    if (!currentGameState) {
+      return this.rejectInput("GAME_NOT_FOUND", "진행 중인 게임이 없습니다.");
+    }
+
+    if (currentGameState.gameId !== input.gameId) {
+      return this.rejectInput("GAME_MISMATCH", "현재 게임과 입력 게임이 일치하지 않습니다.");
+    }
+
+    if (currentGameState.phase !== "in_progress") {
+      return this.rejectInput("GAME_NOT_IN_PROGRESS", "게임 진행 중에만 입력할 수 있습니다.");
+    }
+
+    const previousParticipantState = await this.battleStateRepository.getParticipantState(
+      currentGameState.gameId,
+      input.participantId,
+    );
+    const participantState =
+      previousParticipantState ??
+      this.createParticipantState({
+        assignedRole: input.assignedRole,
+        currentGameState,
+        participantId: input.participantId,
+        socketId: input.socketId,
+      });
+
+    if (participantState.status === "eliminated") {
+      return this.rejectInput("PLAYER_ELIMINATED", "탈락한 플레이어는 입력할 수 없습니다.");
+    }
+
+    if (participantState.status === "finished") {
+      return this.buildAcceptedInputResult({
+        currentGameState,
+        isTypo: false,
+        participantState,
+        typedLength: this.getTextLength(input.typedText),
+        typoIndex: null,
+      });
+    }
+
+    const comparison = this.compareTypedText(currentGameState.prompt.content, input.typedText);
+    const nextParticipantState = this.applyInputResult({
+      comparison,
+      currentGameState,
+      participantState,
+      socketId: input.socketId,
+    });
+
+    await this.battleStateRepository.saveParticipantState(nextParticipantState);
+
+    return this.buildAcceptedInputResult({
+      currentGameState,
+      isTypo: comparison.typoIndex !== null,
+      participantState: nextParticipantState,
+      typedLength: comparison.typedLength,
+      typoIndex: comparison.typoIndex,
+    });
   }
 
   async markTenSecondNoticeSent(currentGameState: CurrentGameState) {
@@ -225,6 +399,168 @@ export class BattleService {
     };
 
     return gameState;
+  }
+
+  private applyInputResult(input: {
+    comparison: {
+      acceptedLength: number;
+      expectedLength: number;
+      isComplete: boolean;
+      typedLength: number;
+      typoIndex: null | number;
+    };
+    currentGameState: CurrentGameState;
+    participantState: BattleParticipantState;
+    socketId: string;
+  }) {
+    const now = new Date().toISOString();
+    const shouldApplyPenalty =
+      input.comparison.typoIndex !== null &&
+      input.comparison.typoIndex !== input.participantState.lastPenaltyIndex;
+    const life = shouldApplyPenalty
+      ? Math.max(0, input.participantState.life - 1)
+      : input.participantState.life;
+    const status = life === 0 ? "eliminated" : input.comparison.isComplete ? "finished" : "playing";
+
+    return {
+      ...input.participantState,
+      acceptedLength: input.comparison.acceptedLength,
+      accuracy: this.calculateAccuracy(
+        input.comparison.acceptedLength,
+        input.comparison.typedLength,
+      ),
+      lastInputAt: now,
+      lastPenaltyIndex:
+        input.comparison.typoIndex === null
+          ? input.participantState.lastPenaltyIndex
+          : input.comparison.typoIndex,
+      life,
+      progressPercent: this.calculateProgressPercent(
+        input.comparison.acceptedLength,
+        input.comparison.expectedLength,
+      ),
+      socketId: input.socketId,
+      status,
+      typoCount: shouldApplyPenalty
+        ? input.participantState.typoCount + 1
+        : input.participantState.typoCount,
+    } satisfies BattleParticipantState;
+  }
+
+  private buildAcceptedInputResult(input: {
+    currentGameState: CurrentGameState;
+    isTypo: boolean;
+    participantState: BattleParticipantState;
+    typedLength: number;
+    typoIndex: null | number;
+  }): BattleInputAcceptedResult {
+    return {
+      data: {
+        acceptedLength: input.participantState.acceptedLength,
+        accuracy: input.participantState.accuracy,
+        expectedLength: this.getTextLength(input.currentGameState.prompt.content),
+        gameId: input.currentGameState.gameId,
+        isEliminated: input.participantState.status === "eliminated",
+        isFinished: input.participantState.status === "finished",
+        isTypo: input.isTypo,
+        life: input.participantState.life,
+        participant: input.participantState,
+        progressPercent: input.participantState.progressPercent,
+        typedLength: input.typedLength,
+        typoIndex: input.typoIndex,
+      },
+      ok: true,
+    };
+  }
+
+  private calculateAccuracy(acceptedLength: number, typedLength: number) {
+    if (typedLength === 0) {
+      return 100;
+    }
+
+    return Math.round((acceptedLength / typedLength) * 1000) / 10;
+  }
+
+  private calculateProgressPercent(acceptedLength: number, expectedLength: number) {
+    if (expectedLength === 0) {
+      return 100;
+    }
+
+    return Math.round((acceptedLength / expectedLength) * 10000) / 100;
+  }
+
+  private compareTypedText(expectedText: string, typedText: string) {
+    const expectedCharacters = this.toCharacters(expectedText);
+    const typedCharacters = this.toCharacters(typedText);
+    const comparisonLength = Math.min(expectedCharacters.length, typedCharacters.length);
+
+    for (let index = 0; index < comparisonLength; index += 1) {
+      if (expectedCharacters[index] !== typedCharacters[index]) {
+        return {
+          acceptedLength: index,
+          expectedLength: expectedCharacters.length,
+          isComplete: false,
+          typedLength: typedCharacters.length,
+          typoIndex: index,
+        };
+      }
+    }
+
+    if (typedCharacters.length > expectedCharacters.length) {
+      return {
+        acceptedLength: expectedCharacters.length,
+        expectedLength: expectedCharacters.length,
+        isComplete: false,
+        typedLength: typedCharacters.length,
+        typoIndex: expectedCharacters.length,
+      };
+    }
+
+    return {
+      acceptedLength: typedCharacters.length,
+      expectedLength: expectedCharacters.length,
+      isComplete: typedCharacters.length === expectedCharacters.length,
+      typedLength: typedCharacters.length,
+      typoIndex: null,
+    };
+  }
+
+  private createParticipantState(input: {
+    assignedRole: ConnectionRole;
+    currentGameState: CurrentGameState;
+    participantId: string;
+    socketId: string;
+  }): BattleParticipantState {
+    return {
+      acceptedLength: 0,
+      accuracy: 100,
+      gameId: input.currentGameState.gameId,
+      lastInputAt: null,
+      lastPenaltyIndex: null,
+      life: DEFAULT_PLAYER_LIFE,
+      participantId: input.participantId,
+      progressPercent: 0,
+      role: input.assignedRole,
+      socketId: input.socketId,
+      status: input.assignedRole === "player" ? "playing" : "spectating",
+      typoCount: 0,
+    };
+  }
+
+  private getTextLength(value: string) {
+    return this.toCharacters(value).length;
+  }
+
+  private rejectInput(code: string, message: string): BattleInputRejectedResult {
+    return {
+      code,
+      message,
+      ok: false,
+    };
+  }
+
+  private toCharacters(value: string) {
+    return Array.from(value.normalize("NFC"));
   }
 
   private async updateConnectionCount(

--- a/apps/backend/src/modules/battle/types/battle-participant-state.ts
+++ b/apps/backend/src/modules/battle/types/battle-participant-state.ts
@@ -1,0 +1,18 @@
+import type { ConnectionRole } from "./current-game-state";
+
+export type BattleParticipantStatus = "playing" | "finished" | "eliminated" | "spectating";
+
+export type BattleParticipantState = {
+  acceptedLength: number;
+  accuracy: number;
+  gameId: string;
+  lastInputAt: null | string;
+  lastPenaltyIndex: null | number;
+  life: number;
+  participantId: string;
+  progressPercent: number;
+  role: ConnectionRole;
+  socketId: string;
+  status: BattleParticipantStatus;
+  typoCount: number;
+};

--- a/apps/backend/src/modules/battle/types/battle-socket-session.ts
+++ b/apps/backend/src/modules/battle/types/battle-socket-session.ts
@@ -1,0 +1,13 @@
+import type { ConnectionRole } from "./current-game-state";
+
+export type BattleActiveConnection = {
+  assignedRole: ConnectionRole;
+  gameId: string;
+  participantId: string;
+  socketId: string;
+};
+
+export type BattleSocketAuthSession = {
+  issuedAt: string;
+  userId: string;
+};

--- a/apps/backend/src/modules/match/match.service.ts
+++ b/apps/backend/src/modules/match/match.service.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { Injectable } from "@nestjs/common";
+import {
+  BATTLE_SOCKET_AUTH_TOKEN_TTL_SECONDS,
+  getBattleSocketAuthTokenKey,
+} from "../battle/constants/battle-redis-keys";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { RedisService } from "../storage/redis/redis.service";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
@@ -21,6 +25,7 @@ export class MatchService {
     const gameStatus = await this.redis.instance.hget("game:current", "status");
     const role = gameStatus === "in_progress" ? "spectator" : "player";
     const status = gameStatus === "in_progress" ? "spectating" : "waiting";
+    const socketAuthToken = `ws_tk_${randomUUID()}`;
 
     await this.redis.instance.sadd("lobby:players", userId);
     await this.redis.instance.hset(
@@ -36,13 +41,22 @@ export class MatchService {
       "joinedAt",
       new Date().toISOString(),
     );
+    await this.redis.instance.set(
+      getBattleSocketAuthTokenKey(socketAuthToken),
+      JSON.stringify({
+        issuedAt: new Date().toISOString(),
+        userId,
+      }),
+      "EX",
+      BATTLE_SOCKET_AUTH_TOKEN_TTL_SECONDS,
+    );
 
     return {
       userId,
       role: role,
       status: status,
       socketNamespace: "/battle",
-      socketAuthToken: `ws_tk_${randomUUID()}`,
+      socketAuthToken,
     };
   }
 

--- a/apps/backend/test/battle.gateway.spec.ts
+++ b/apps/backend/test/battle.gateway.spec.ts
@@ -51,6 +51,11 @@ function createSocket() {
     },
     data: {},
     emit,
+    handshake: {
+      auth: {
+        token: "ws_tk_123",
+      },
+    },
     id: "socket-1",
     join,
   } as unknown as Socket;
@@ -101,17 +106,28 @@ describe("BattleGateway", () => {
       waiting,
     });
     const getWelcomeMessage = jest.fn(() => ({ message: "connected" }));
+    const verifySocketAuthToken = jest.fn().mockResolvedValue({ userId: "user-1" });
     const battleService = {
       getWelcomeMessage,
       registerConnection,
+      verifySocketAuthToken,
     } as unknown as BattleService;
     const gateway = new BattleGateway(battleService, {} as BattleBroadcastService);
     const { broadcastEmit, broadcastTo, emit, join, socket } = createSocket();
 
     await gateway.handleConnection(socket);
 
-    expect(registerConnection).toHaveBeenCalledWith();
-    expect(socket.data).toMatchObject({ assignedRole: "player", gameId: state.gameId });
+    expect(verifySocketAuthToken).toHaveBeenCalledWith("ws_tk_123");
+    expect(registerConnection).toHaveBeenCalledWith({
+      participantId: "user-1",
+      socketId: "socket-1",
+    });
+    expect(socket.data).toMatchObject({
+      assignedRole: "player",
+      gameId: state.gameId,
+      participantId: "user-1",
+      userId: "user-1",
+    });
     expect(join).toHaveBeenCalledWith("battle:game-1");
     expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_WELCOME, { message: "connected" });
     expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_STATE, state);
@@ -148,12 +164,15 @@ describe("BattleGateway", () => {
     gateway.server = server;
     socket.data.assignedRole = "player";
     socket.data.gameId = "game-1";
+    socket.data.participantId = "user-1";
 
     await gateway.handleDisconnect(socket);
 
     expect(unregisterConnection).toHaveBeenCalledWith({
       assignedRole: "player",
       gameId: "game-1",
+      participantId: "user-1",
+      socketId: "socket-1",
     });
     expect(to).toHaveBeenCalledWith("battle:game-1");
     expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_WAITING, waiting);

--- a/apps/backend/test/battle.input.spec.ts
+++ b/apps/backend/test/battle.input.spec.ts
@@ -1,0 +1,480 @@
+import type { Server, Socket } from "socket.io";
+
+jest.mock("uuid", () => ({
+  v7: jest.fn(() => "uuid-v7"),
+}));
+
+import { SOCKET_EVENTS } from "../src/common/constants/socket-events";
+import { BattleGateway } from "../src/modules/battle/gateways/battle.gateway";
+import type { BattleStateRepository } from "../src/modules/battle/repositories/battle-state.repository";
+import type { PromptRepository } from "../src/modules/battle/repositories/prompt.repository";
+import { BattleService } from "../src/modules/battle/services/battle.service";
+import type { BattleBroadcastService } from "../src/modules/battle/services/battle-broadcast.service";
+import type { BattleParticipantState } from "../src/modules/battle/types/battle-participant-state";
+import type { CurrentGameState } from "../src/modules/battle/types/current-game-state";
+
+const prompt = {
+  content: "hello",
+  contentLength: 5,
+  id: 1,
+  slug: "hello",
+  title: "Hello",
+};
+
+function createGameState(overrides: Partial<CurrentGameState> = {}): CurrentGameState {
+  return {
+    createdAt: "2026-05-06T00:00:00.000Z",
+    gameEndedAt: null,
+    gameId: "game-1",
+    gameStartedAt: "2026-05-06T00:01:00.000Z",
+    hasTenSecondNoticeSent: false,
+    minPlayers: 4,
+    phase: "in_progress",
+    playerCount: 1,
+    prompt,
+    spectatorCount: 0,
+    updatedAt: "2026-05-06T00:01:00.000Z",
+    waitingEndsAt: null,
+    waitingStartedAt: null,
+    ...overrides,
+  };
+}
+
+function createParticipantState(
+  overrides: Partial<BattleParticipantState> = {},
+): BattleParticipantState {
+  return {
+    acceptedLength: 0,
+    accuracy: 100,
+    gameId: "game-1",
+    lastInputAt: null,
+    lastPenaltyIndex: null,
+    life: 3,
+    participantId: "socket-1",
+    progressPercent: 0,
+    role: "player",
+    socketId: "socket-1",
+    status: "playing",
+    typoCount: 0,
+    ...overrides,
+  };
+}
+
+function createService(input: {
+  currentGameState?: CurrentGameState | null;
+  participantState?: BattleParticipantState | null;
+  saveParticipantState?: jest.Mock;
+}) {
+  const saveParticipantState = input.saveParticipantState ?? jest.fn();
+  const repository = {
+    getCurrentGameState: jest.fn().mockResolvedValue(input.currentGameState ?? createGameState()),
+    getParticipantState: jest.fn().mockResolvedValue(input.participantState ?? null),
+    saveParticipantState,
+  } as unknown as BattleStateRepository;
+
+  return {
+    repository,
+    saveParticipantState,
+    service: new BattleService(repository, {} as PromptRepository),
+  };
+}
+
+function createServer() {
+  const emit = jest.fn();
+  const to = jest.fn(() => ({ emit }));
+
+  return {
+    emit,
+    server: { to } as unknown as Server,
+    to,
+  };
+}
+
+function createSocket(overrides: { assignedRole?: "player" | "spectator" } = {}) {
+  return {
+    data: {
+      assignedRole: overrides.assignedRole ?? "player",
+      participantId: "user-1",
+    },
+    id: "socket-1",
+  } as unknown as Socket;
+}
+
+describe("BattleService input validation", () => {
+  it("accepts a valid prefix and stores server-calculated progress", async () => {
+    const { saveParticipantState, service } = createService({});
+
+    const result = await service.validateInput({
+      assignedRole: "player",
+      gameId: "game-1",
+      participantId: "socket-1",
+      socketId: "socket-1",
+      typedText: "hel",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected accepted input");
+    expect(result.data).toMatchObject({
+      acceptedLength: 3,
+      accuracy: 100,
+      isEliminated: false,
+      isFinished: false,
+      isTypo: false,
+      life: 3,
+      progressPercent: 60,
+      typedLength: 3,
+      typoIndex: null,
+    });
+    expect(saveParticipantState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        acceptedLength: 3,
+        life: 3,
+        progressPercent: 60,
+        status: "playing",
+      }),
+    );
+  });
+
+  it("penalizes the first typo at a position", async () => {
+    const { saveParticipantState, service } = createService({});
+
+    const result = await service.validateInput({
+      assignedRole: "player",
+      gameId: "game-1",
+      participantId: "socket-1",
+      socketId: "socket-1",
+      typedText: "hez",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected accepted input");
+    expect(result.data).toMatchObject({
+      acceptedLength: 2,
+      isTypo: true,
+      life: 2,
+      progressPercent: 40,
+      typoIndex: 2,
+    });
+    expect(saveParticipantState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastPenaltyIndex: 2,
+        life: 2,
+        typoCount: 1,
+      }),
+    );
+  });
+
+  it("does not apply the same typo penalty twice", async () => {
+    const { saveParticipantState, service } = createService({
+      participantState: createParticipantState({
+        lastPenaltyIndex: 2,
+        life: 2,
+        typoCount: 1,
+      }),
+    });
+
+    const result = await service.validateInput({
+      assignedRole: "player",
+      gameId: "game-1",
+      participantId: "socket-1",
+      socketId: "socket-1",
+      typedText: "hez",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected accepted input");
+    expect(result.data.life).toBe(2);
+    expect(saveParticipantState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastPenaltyIndex: 2,
+        life: 2,
+        typoCount: 1,
+      }),
+    );
+  });
+
+  it("marks a player as eliminated when life reaches zero", async () => {
+    const { saveParticipantState, service } = createService({
+      participantState: createParticipantState({
+        life: 1,
+      }),
+    });
+
+    const result = await service.validateInput({
+      assignedRole: "player",
+      gameId: "game-1",
+      participantId: "socket-1",
+      socketId: "socket-1",
+      typedText: "hez",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected accepted input");
+    expect(result.data.isEliminated).toBe(true);
+    expect(saveParticipantState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        life: 0,
+        status: "eliminated",
+      }),
+    );
+  });
+
+  it("marks exact completion as finished", async () => {
+    const { saveParticipantState, service } = createService({});
+
+    const result = await service.validateInput({
+      assignedRole: "player",
+      gameId: "game-1",
+      participantId: "socket-1",
+      socketId: "socket-1",
+      typedText: "hello",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected accepted input");
+    expect(result.data).toMatchObject({
+      acceptedLength: 5,
+      isFinished: true,
+      progressPercent: 100,
+    });
+    expect(saveParticipantState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "finished",
+      }),
+    );
+  });
+
+  it("rejects spectator input", async () => {
+    const { saveParticipantState, service } = createService({});
+
+    const result = await service.validateInput({
+      assignedRole: "spectator",
+      gameId: "game-1",
+      participantId: "socket-1",
+      socketId: "socket-1",
+      typedText: "hello",
+    });
+
+    expect(result).toMatchObject({
+      code: "NOT_PLAYER",
+      ok: false,
+    });
+    expect(saveParticipantState).not.toHaveBeenCalled();
+  });
+
+  it("hides prompt content before the game starts", () => {
+    const { service } = createService({
+      currentGameState: createGameState({
+        gameStartedAt: null,
+        phase: "waiting",
+        waitingEndsAt: "2026-05-06T00:15:00.000Z",
+        waitingStartedAt: "2026-05-06T00:00:00.000Z",
+      }),
+    });
+
+    const payload = service.buildStatePayload(
+      createGameState({
+        gameStartedAt: null,
+        phase: "waiting",
+        waitingEndsAt: "2026-05-06T00:15:00.000Z",
+        waitingStartedAt: "2026-05-06T00:00:00.000Z",
+      }),
+    );
+
+    expect(payload.prompt).toEqual({
+      contentLength: 5,
+      id: 1,
+      title: "Hello",
+    });
+  });
+});
+
+describe("BattleGateway input handling", () => {
+  it("broadcasts progress after accepted input", async () => {
+    const participant = createParticipantState({
+      acceptedLength: 3,
+      progressPercent: 60,
+    });
+    const validateInput = jest.fn().mockResolvedValue({
+      data: {
+        gameId: "game-1",
+        isEliminated: false,
+        participant,
+      },
+      ok: true,
+    });
+    const gateway = new BattleGateway(
+      { validateInput } as unknown as BattleService,
+      {} as BattleBroadcastService,
+    );
+    const { emit, server, to } = createServer();
+    gateway.server = server;
+
+    const result = await gateway.handleInput(
+      {
+        gameId: "game-1",
+        typedText: "hel",
+      },
+      createSocket(),
+    );
+
+    expect(validateInput).toHaveBeenCalledWith({
+      assignedRole: "player",
+      cursorPosition: undefined,
+      gameId: "game-1",
+      participantId: "user-1",
+      socketId: "socket-1",
+      typedText: "hel",
+    });
+    expect(to).toHaveBeenCalledWith("battle:game-1");
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_PROGRESS, {
+      gameId: "game-1",
+      participant,
+    });
+    expect(result).toMatchObject({
+      event: SOCKET_EVENTS.BATTLE_INPUT_RESULT,
+    });
+  });
+
+  it("broadcasts elimination after accepted input removes the last life", async () => {
+    const participant = createParticipantState({
+      life: 0,
+      status: "eliminated",
+    });
+    const validateInput = jest.fn().mockResolvedValue({
+      data: {
+        gameId: "game-1",
+        isEliminated: true,
+        participant,
+      },
+      ok: true,
+    });
+    const gateway = new BattleGateway(
+      { validateInput } as unknown as BattleService,
+      {} as BattleBroadcastService,
+    );
+    const { emit, server } = createServer();
+    gateway.server = server;
+
+    await gateway.handleInput(
+      {
+        gameId: "game-1",
+        typedText: "hez",
+      },
+      createSocket(),
+    );
+
+    expect(emit).toHaveBeenCalledWith(SOCKET_EVENTS.BATTLE_ELIMINATED, {
+      gameId: "game-1",
+      participantId: "socket-1",
+      reason: "typo",
+      socketId: "socket-1",
+      userId: "socket-1",
+    });
+  });
+});
+
+describe("BattleService socket auth and connection dedupe", () => {
+  it("verifies socket auth tokens and refreshes their TTL", async () => {
+    const getSocketAuthSession = jest.fn().mockResolvedValue({
+      issuedAt: "2026-05-06T00:00:00.000Z",
+      userId: "user-1",
+    });
+    const refreshSocketAuthSession = jest.fn();
+    const service = new BattleService(
+      {
+        getSocketAuthSession,
+        refreshSocketAuthSession,
+      } as unknown as BattleStateRepository,
+      {} as PromptRepository,
+    );
+
+    const session = await service.verifySocketAuthToken("ws_tk_123");
+
+    expect(session).toEqual({
+      issuedAt: "2026-05-06T00:00:00.000Z",
+      userId: "user-1",
+    });
+    expect(getSocketAuthSession).toHaveBeenCalledWith("ws_tk_123");
+    expect(refreshSocketAuthSession).toHaveBeenCalledWith("ws_tk_123");
+  });
+
+  it("does not increment player count for a duplicate waiting connection from the same user", async () => {
+    const currentGameState = createGameState({
+      gameStartedAt: null,
+      phase: "waiting",
+      playerCount: 1,
+      waitingEndsAt: "2026-05-06T00:15:00.000Z",
+      waitingStartedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const saveActiveConnection = jest.fn();
+    const saveCurrentGameState = jest.fn();
+    const service = new BattleService(
+      {
+        getActiveConnection: jest.fn().mockResolvedValue({
+          assignedRole: "player",
+          gameId: "game-1",
+          participantId: "user-1",
+          socketId: "old-socket",
+        }),
+        getCurrentGameState: jest.fn().mockResolvedValue(currentGameState),
+        saveActiveConnection,
+        saveCurrentGameState,
+      } as unknown as BattleStateRepository,
+      {} as PromptRepository,
+    );
+
+    const result = await service.registerConnection({
+      participantId: "user-1",
+      socketId: "new-socket",
+    });
+
+    expect(result.assignedRole).toBe("player");
+    expect(result.state.playerCount).toBe(1);
+    expect(saveCurrentGameState).not.toHaveBeenCalled();
+    expect(saveActiveConnection).toHaveBeenCalledWith({
+      assignedRole: "player",
+      gameId: "game-1",
+      participantId: "user-1",
+      socketId: "new-socket",
+    });
+  });
+
+  it("ignores an old socket disconnect after the same user reconnects", async () => {
+    const saveCurrentGameState = jest.fn();
+    const deleteActiveConnection = jest.fn();
+    const service = new BattleService(
+      {
+        deleteActiveConnection,
+        getActiveConnection: jest.fn().mockResolvedValue({
+          assignedRole: "player",
+          gameId: "game-1",
+          participantId: "user-1",
+          socketId: "new-socket",
+        }),
+        getCurrentGameState: jest.fn().mockResolvedValue(
+          createGameState({
+            gameStartedAt: null,
+            phase: "waiting",
+            playerCount: 1,
+            waitingEndsAt: "2026-05-06T00:15:00.000Z",
+            waitingStartedAt: "2026-05-06T00:00:00.000Z",
+          }),
+        ),
+        saveCurrentGameState,
+      } as unknown as BattleStateRepository,
+      {} as PromptRepository,
+    );
+
+    const result = await service.unregisterConnection({
+      assignedRole: "player",
+      gameId: "game-1",
+      participantId: "user-1",
+      socketId: "old-socket",
+    });
+
+    expect(result).toBeNull();
+    expect(deleteActiveConnection).not.toHaveBeenCalled();
+    expect(saveCurrentGameState).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/test/match.service.spec.ts
+++ b/apps/backend/test/match.service.spec.ts
@@ -1,0 +1,51 @@
+jest.mock("node:crypto", () => ({
+  randomUUID: jest.fn(() => "socket-token-id"),
+}));
+
+import {
+  BATTLE_SOCKET_AUTH_TOKEN_TTL_SECONDS,
+  getBattleSocketAuthTokenKey,
+} from "../src/modules/battle/constants/battle-redis-keys";
+import { MatchService } from "../src/modules/match/match.service";
+import type { RedisService } from "../src/modules/storage/redis/redis.service";
+import type { UsersRepository } from "../src/modules/users/users.repository";
+
+describe("MatchService", () => {
+  it("stores a short-lived socket auth token when a user joins the game", async () => {
+    const hget = jest.fn().mockResolvedValue("waiting");
+    const hset = jest.fn();
+    const sadd = jest.fn();
+    const set = jest.fn();
+    const usersRepository = {
+      findById: jest.fn().mockResolvedValue({
+        avatarUrl: "https://example.com/avatar.png",
+        nickname: "Jay",
+      }),
+    } as unknown as UsersRepository;
+    const redisService = {
+      instance: {
+        hget,
+        hset,
+        sadd,
+        set,
+      },
+    } as unknown as RedisService;
+    const service = new MatchService(redisService, usersRepository);
+
+    const result = await service.joinGame("user-1");
+
+    expect(result).toMatchObject({
+      role: "player",
+      socketAuthToken: "ws_tk_socket-token-id",
+      socketNamespace: "/battle",
+      status: "waiting",
+      userId: "user-1",
+    });
+    expect(set).toHaveBeenCalledWith(
+      getBattleSocketAuthTokenKey("ws_tk_socket-token-id"),
+      expect.stringContaining('"userId":"user-1"'),
+      "EX",
+      BATTLE_SOCKET_AUTH_TOKEN_TTL_SECONDS,
+    );
+  });
+});


### PR DESCRIPTION
## 작업 내용
- 플레이서 타자 검증 및 사용자 소캣 인증 추가

## 상세 변경 사항
- battle:input 이벤트 추가
- 서버가 현재 prompt.content 기준으로 typedText를 직접 검증
- 정상 prefix면 acceptedLength, progressPercent, accuracy 계산
- 오타면 최초 오타 위치 typoIndex 계산
- 같은 위치 오타는 생명 중복 차감 방지
- 기본 생명 3
- 생명 0이면 eliminated
- 정확히 끝까지 입력하면 finished
- 결과는 요청자에게 battle:input-result
- 진행 상황은 방 전체에 battle:progress
- 탈락 시 방 전체에 battle:eliminated
- 대기 중 battle:state에서는 지문 본문을 숨기도록 처리

## 관련 이슈
- closes #

## 체크리스트
- [ ] 컨벤션 규칙에 맞게 작성했나요?
- [ ] 빌드가 정상적으로 통과되었나요?
- [ ] 로컬 테스트를 완료헀나요?