### PR TITLE
게임 종료 로직 추가

### DIFF
--- a/apps/backend/src/modules/battle/gateways/battle.gateway.ts
+++ b/apps/backend/src/modules/battle/gateways/battle.gateway.ts
@@ -12,6 +12,7 @@ import type { Server, Socket } from "socket.io";
 import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
 import type { BattleInputDto } from "../dto/battle-input.dto";
 import type { BattleReadyDto } from "../dto/battle-ready.dto";
+import type { BattleFinishedResult } from "../services/battle.service";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { BattleService } from "../services/battle.service";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
@@ -98,7 +99,14 @@ export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, 
         ...this.getUserIdPayload(client),
       });
 
-      this.battleService.handleDisconnectUser(this.getParticipantId(client));
+      await this.battleService.handleDisconnectUser(this.getParticipantId(client));
+
+      const finishedResult = await this.battleService.finishCurrentGameIfNeeded();
+
+      if (finishedResult) {
+        this.emitFinishedGame(roomName, finishedResult);
+        return;
+      }
     }
 
     if (updatedGameState.phase === "waiting") {
@@ -144,6 +152,14 @@ export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, 
           userId: result.data.participant.participantId,
         });
       }
+
+      if (result.data.isFinished || result.data.isEliminated) {
+        const finishedResult = await this.battleService.finishCurrentGameIfNeeded();
+
+        if (finishedResult) {
+          this.emitFinishedGame(roomName, finishedResult);
+        }
+      }
     }
 
     return {
@@ -179,6 +195,21 @@ export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect, 
 
   private getBattleRoomName(gameId: string) {
     return `battle:${gameId}`;
+  }
+
+  private emitFinishedGame(roomName: string, finishedResult: BattleFinishedResult) {
+    this.server
+      .to(roomName)
+      .emit(
+        SOCKET_EVENTS.BATTLE_FINISHED,
+        this.battleService.buildFinishedPayload(finishedResult.finishedGameState),
+      );
+    this.server
+      .to(roomName)
+      .emit(
+        SOCKET_EVENTS.BATTLE_STATE,
+        this.battleService.buildStatePayload(finishedResult.finishedGameState),
+      );
   }
 
   private getGameId(client: Socket) {

--- a/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
+++ b/apps/backend/src/modules/battle/repositories/battle-state.repository.ts
@@ -6,6 +6,7 @@ import {
   getBattleActiveConnectionKey,
   getBattleSocketAuthTokenKey,
 } from "../constants/battle-redis-keys";
+import type { BattleGameResult } from "../types/battle-game-result";
 import type { BattleParticipantState } from "../types/battle-participant-state";
 import type {
   BattleActiveConnection,
@@ -23,6 +24,18 @@ export class BattleStateRepository {
   async acquireTimerLock(lockToken: string, ttlSeconds: number) {
     const result = await this.redisService.instance.set(
       BATTLE_TIMER_LOCK_KEY,
+      lockToken,
+      "EX",
+      ttlSeconds,
+      "NX",
+    );
+
+    return result === "OK";
+  }
+
+  async acquireGameFinishLock(gameId: string, lockToken: string, ttlSeconds: number) {
+    const result = await this.redisService.instance.set(
+      `battle:game:${gameId}:finish-lock`,
       lockToken,
       "EX",
       ttlSeconds,
@@ -93,6 +106,23 @@ export class BattleStateRepository {
     return JSON.parse(value) as BattleParticipantState;
   }
 
+  async getPlayerParticipantStates(gameId: string) {
+    const participantIds = await this.redisService.instance.zrange(
+      `battle:game:${gameId}:scoreboard`,
+      0,
+      -1,
+    );
+
+    const participantStates = await Promise.all(
+      participantIds.map((participantId) => this.getParticipantState(gameId, participantId)),
+    );
+
+    return participantStates.filter(
+      (participantState): participantState is BattleParticipantState =>
+        participantState?.role === "player",
+    );
+  }
+
   async saveParticipantState(participantState: BattleParticipantState) {
     await this.redisService.instance.set(
       `battle:game:${participantState.gameId}:participant:${participantState.participantId}`,
@@ -132,6 +162,8 @@ export class BattleStateRepository {
         const nextState: BattleParticipantState = {
           acceptedLength: 0,
           accuracy: 100,
+          eliminatedAt: null,
+          finishedAt: null,
           gameId,
           lastInputAt: null,
           lastPenaltyIndex: null,
@@ -159,12 +191,26 @@ export class BattleStateRepository {
 
     if (!participantState) return;
 
+    if (participantState.status === "eliminated" || participantState.status === "finished") {
+      return;
+    }
+
+    const disconnectedAt = new Date().toISOString();
+
     await this.saveParticipantState({
       ...participantState,
+      eliminatedAt: participantState.eliminatedAt ?? disconnectedAt,
       life: 0,
       status: "eliminated",
-      lastInputAt: new Date().toISOString(),
+      lastInputAt: disconnectedAt,
     });
+  }
+
+  async saveGameResult(result: BattleGameResult) {
+    await this.redisService.instance.set(
+      `battle:game:${result.gameId}:result`,
+      JSON.stringify(result),
+    );
   }
 
   async refreshSocketAuthSession(token: string) {

--- a/apps/backend/src/modules/battle/services/battle-cycle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle-cycle.service.ts
@@ -3,6 +3,7 @@ import { SOCKET_EVENTS } from "../../../common/constants/socket-events";
 import { createUuidV7 } from "../../../common/uuid";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { BattleStateRepository } from "../repositories/battle-state.repository";
+import type { BattleFinishedResult } from "./battle.service";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { BattleService } from "./battle.service";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
@@ -43,14 +44,7 @@ export class BattleCycleService implements OnModuleDestroy, OnModuleInit {
     }
 
     this.logger.log(`Finished game ${finishedResult.finishedGameState.gameId}`);
-    this.battleBroadcastService.emitToAll(
-      SOCKET_EVENTS.BATTLE_FINISHED,
-      this.battleService.buildStatePayload(finishedResult.finishedGameState),
-    );
-    this.battleBroadcastService.emitToAll(
-      SOCKET_EVENTS.BATTLE_WAITING,
-      this.battleService.buildWaitingPayload(finishedResult.nextWaitingGameState),
-    );
+    this.emitFinishedGame(finishedResult);
 
     return finishedResult;
   }
@@ -66,6 +60,36 @@ export class BattleCycleService implements OnModuleDestroy, OnModuleInit {
     }
 
     const currentGameState = await this.battleService.ensureCurrentGameState();
+
+    if (currentGameState.phase === "finished") {
+      const nextWaitingGameState =
+        await this.battleService.startNextWaitingGameIfReady(currentGameState);
+
+      if (nextWaitingGameState) {
+        this.logger.log(`Opened waiting room for game ${nextWaitingGameState.gameId}`);
+        this.battleBroadcastService.emitToAll(
+          SOCKET_EVENTS.BATTLE_WAITING,
+          this.battleService.buildWaitingPayload(nextWaitingGameState),
+        );
+        this.battleBroadcastService.emitToAll(
+          SOCKET_EVENTS.BATTLE_STATE,
+          this.battleService.buildStatePayload(nextWaitingGameState),
+        );
+      }
+
+      return;
+    }
+
+    if (currentGameState.phase === "in_progress") {
+      const finishedResult = await this.battleService.finishCurrentGameIfNeeded(currentGameState);
+
+      if (finishedResult) {
+        this.logger.log(`Finished game ${finishedResult.finishedGameState.gameId}`);
+        this.emitFinishedGame(finishedResult);
+      }
+
+      return;
+    }
 
     if (currentGameState.phase !== "waiting") {
       return;
@@ -111,6 +135,17 @@ export class BattleCycleService implements OnModuleDestroy, OnModuleInit {
     this.battleBroadcastService.emitToAll(
       SOCKET_EVENTS.BATTLE_WAITING,
       this.battleService.buildWaitingPayload(currentGameState),
+    );
+  }
+
+  private emitFinishedGame(finishedResult: BattleFinishedResult) {
+    this.battleBroadcastService.emitToAll(
+      SOCKET_EVENTS.BATTLE_FINISHED,
+      this.battleService.buildFinishedPayload(finishedResult.finishedGameState),
+    );
+    this.battleBroadcastService.emitToAll(
+      SOCKET_EVENTS.BATTLE_STATE,
+      this.battleService.buildStatePayload(finishedResult.finishedGameState),
     );
   }
 

--- a/apps/backend/src/modules/battle/services/battle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle.service.ts
@@ -5,11 +5,19 @@ import type { BattleReadyDto } from "../dto/battle-ready.dto";
 import { BattleStateRepository } from "../repositories/battle-state.repository";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { PromptRepository } from "../repositories/prompt.repository";
+import type {
+  BattleFinishReason,
+  BattleGameResult,
+  BattleRankingEntry,
+} from "../types/battle-game-result";
 import type { BattleParticipantState } from "../types/battle-participant-state";
 import type { ConnectionRole, CurrentGameState } from "../types/current-game-state";
 
 // const WAITING_DURATION_SECONDS = 15 * 60;
 const WAITING_DURATION_SECONDS = 15;
+const GAME_DURATION_SECONDS = 15 * 60;
+const FINISHED_DURATION_SECONDS = 30;
+const FINISH_LOCK_TTL_SECONDS = FINISHED_DURATION_SECONDS + 10;
 const DEFAULT_PLAYER_LIFE = 3;
 
 type BattleInputValidationInput = {
@@ -59,6 +67,11 @@ type BattleInputAcceptedResult = {
 
 export type BattleInputValidationResult = BattleInputAcceptedResult | BattleInputRejectedResult;
 
+export type BattleFinishedResult = {
+  finishedGameState: CurrentGameState;
+  result: BattleGameResult;
+};
+
 @Injectable()
 export class BattleService {
   constructor(
@@ -69,7 +82,7 @@ export class BattleService {
   async ensureCurrentGameState() {
     const currentGameState = await this.battleStateRepository.getCurrentGameState();
 
-    if (currentGameState && currentGameState.phase !== "finished") {
+    if (currentGameState) {
       return currentGameState;
     }
 
@@ -144,6 +157,21 @@ export class BattleService {
       waitingEndsAt: currentGameState.waitingEndsAt,
       gameStartedAt: currentGameState.gameStartedAt,
       gameEndedAt: currentGameState.gameEndedAt,
+      finishReason: currentGameState.finishReason ?? null,
+      nextWaitingStartsAt: currentGameState.nextWaitingStartsAt ?? null,
+      rankings: currentGameState.rankings ?? [],
+      winnerParticipantId: currentGameState.winnerParticipantId ?? null,
+    };
+  }
+
+  buildFinishedPayload(currentGameState: CurrentGameState) {
+    return {
+      finishedAt: currentGameState.gameEndedAt,
+      gameId: currentGameState.gameId,
+      nextWaitingStartsAt: currentGameState.nextWaitingStartsAt ?? null,
+      rankings: currentGameState.rankings ?? [],
+      reason: currentGameState.finishReason ?? null,
+      winnerParticipantId: currentGameState.winnerParticipantId ?? null,
     };
   }
 
@@ -188,7 +216,7 @@ export class BattleService {
     }
 
     const assignedRole: ConnectionRole =
-      currentGameState.phase === "in_progress" ? "spectator" : "player";
+      currentGameState.phase === "waiting" ? "player" : "spectator";
     const updatedGameState = await this.updateConnectionCount(currentGameState, assignedRole, 1);
     await this.battleStateRepository.saveActiveConnection({
       assignedRole,
@@ -328,12 +356,17 @@ export class BattleService {
     const startedAt = new Date().toISOString();
     const startedGameState = {
       ...currentGameState,
+      finishReason: null,
       phase: "in_progress" as const,
       gameStartedAt: startedAt,
+      gameEndedAt: null,
       hasTenSecondNoticeSent: false,
+      nextWaitingStartsAt: null,
+      rankings: [],
       updatedAt: startedAt,
       waitingEndsAt: null,
       waitingStartedAt: null,
+      winnerParticipantId: null,
     };
 
     await this.battleStateRepository.saveCurrentGameState(startedGameState);
@@ -348,10 +381,15 @@ export class BattleService {
     const waitingEndsAt = new Date(now.getTime() + WAITING_DURATION_SECONDS * 1000).toISOString();
     const restartedWaitingGameState = {
       ...currentGameState,
+      finishReason: null,
+      gameEndedAt: null,
       hasTenSecondNoticeSent: false,
+      nextWaitingStartsAt: null,
+      rankings: [],
       updatedAt: waitingStartedAt,
       waitingEndsAt,
       waitingStartedAt,
+      winnerParticipantId: null,
     };
 
     await this.battleStateRepository.saveCurrentGameState(restartedWaitingGameState);
@@ -360,28 +398,111 @@ export class BattleService {
     return restartedWaitingGameState;
   }
 
-  async finishCurrentGame() {
+  async finishCurrentGame(reason?: BattleFinishReason): Promise<BattleFinishedResult | null> {
     const currentGameState = await this.getCurrentGameState();
 
     if (!currentGameState || currentGameState.phase !== "in_progress") {
       return null;
     }
 
+    const hasLock = await this.battleStateRepository.acquireGameFinishLock(
+      currentGameState.gameId,
+      createUuidV7(),
+      FINISH_LOCK_TTL_SECONDS,
+    );
+
+    if (!hasLock) {
+      return null;
+    }
+
+    const lockedGameState = await this.getCurrentGameState();
+
+    if (
+      !lockedGameState ||
+      lockedGameState.gameId !== currentGameState.gameId ||
+      lockedGameState.phase !== "in_progress"
+    ) {
+      return null;
+    }
+
+    const participants = await this.battleStateRepository.getPlayerParticipantStates(
+      lockedGameState.gameId,
+    );
+    const finishReason = this.resolveFinishReason(lockedGameState, participants) ?? reason;
+
+    if (!finishReason) {
+      return null;
+    }
+
     const finishedAt = new Date().toISOString();
+    const result = this.buildGameResult({
+      finishedAt,
+      participants,
+      reason: finishReason,
+      gameId: lockedGameState.gameId,
+    });
     const finishedGameState = {
-      ...currentGameState,
+      ...lockedGameState,
+      finishReason,
       phase: "finished" as const,
       gameEndedAt: finishedAt,
+      nextWaitingStartsAt: new Date(
+        new Date(finishedAt).getTime() + FINISHED_DURATION_SECONDS * 1000,
+      ).toISOString(),
+      rankings: result.rankings,
       updatedAt: finishedAt,
+      winnerParticipantId: result.winnerParticipantId,
     };
-    const nextWaitingGameState = await this.createWaitingGameState(new Date());
 
-    await this.battleStateRepository.saveCurrentGameState(nextWaitingGameState);
+    await this.battleStateRepository.saveCurrentGameState(finishedGameState);
+    await this.battleStateRepository.saveGameResult(result);
 
     return {
       finishedGameState,
-      nextWaitingGameState,
+      result,
     };
+  }
+
+  async finishCurrentGameIfNeeded(
+    currentGameState?: CurrentGameState,
+  ): Promise<BattleFinishedResult | null> {
+    const gameState = currentGameState ?? (await this.getCurrentGameState());
+
+    if (!gameState || gameState.phase !== "in_progress") {
+      return null;
+    }
+
+    const participants = await this.battleStateRepository.getPlayerParticipantStates(
+      gameState.gameId,
+    );
+    const reason = this.resolveFinishReason(gameState, participants);
+
+    if (!reason) {
+      return null;
+    }
+
+    return this.finishCurrentGame(reason);
+  }
+
+  async startNextWaitingGameIfReady(currentGameState?: CurrentGameState) {
+    const gameState = currentGameState ?? (await this.getCurrentGameState());
+
+    if (!gameState || gameState.phase !== "finished") {
+      return null;
+    }
+
+    if (
+      gameState.nextWaitingStartsAt &&
+      new Date(gameState.nextWaitingStartsAt).getTime() > Date.now()
+    ) {
+      return null;
+    }
+
+    const waitingGameState = await this.createWaitingGameState(new Date());
+
+    await this.battleStateRepository.saveCurrentGameState(waitingGameState);
+
+    return waitingGameState;
   }
 
   private async createWaitingGameState(now: Date) {
@@ -392,18 +513,22 @@ export class BattleService {
 
     const gameState = {
       createdAt: waitingStartedAt,
+      finishReason: null,
       gameEndedAt: null,
       gameStartedAt: null,
       gameId,
       hasTenSecondNoticeSent: false,
+      nextWaitingStartsAt: null,
       phase: "waiting" as const,
       playerCount: 0,
       minPlayers: 1, // default = 4
       prompt,
+      rankings: [],
       spectatorCount: 0,
       updatedAt: waitingStartedAt,
       waitingEndsAt,
       waitingStartedAt,
+      winnerParticipantId: null,
     };
 
     return gameState;
@@ -429,6 +554,14 @@ export class BattleService {
       ? Math.max(0, input.participantState.life - 1)
       : input.participantState.life;
     const status = life === 0 ? "eliminated" : input.comparison.isComplete ? "finished" : "playing";
+    const eliminatedAt =
+      status === "eliminated" && input.participantState.status !== "eliminated"
+        ? now
+        : (input.participantState.eliminatedAt ?? null);
+    const finishedAt =
+      status === "finished" && input.participantState.status !== "finished"
+        ? now
+        : (input.participantState.finishedAt ?? null);
 
     return {
       ...input.participantState,
@@ -437,6 +570,8 @@ export class BattleService {
         input.comparison.acceptedLength,
         input.comparison.typedLength,
       ),
+      eliminatedAt,
+      finishedAt,
       lastInputAt: now,
       lastPenaltyIndex:
         input.comparison.typoIndex === null
@@ -480,6 +615,172 @@ export class BattleService {
       },
       ok: true,
     };
+  }
+
+  private buildGameResult(input: {
+    finishedAt: string;
+    gameId: string;
+    participants: BattleParticipantState[];
+    reason: BattleFinishReason;
+  }): BattleGameResult {
+    const rankings = this.rankParticipants(input.participants, input.reason);
+    const winner = rankings.find((ranking) => ranking.isWinner) ?? null;
+
+    return {
+      finishedAt: input.finishedAt,
+      gameId: input.gameId,
+      rankings,
+      reason: input.reason,
+      winnerParticipantId: winner?.participantId ?? null,
+    };
+  }
+
+  private resolveFinishReason(
+    currentGameState: CurrentGameState,
+    participants: BattleParticipantState[],
+  ): BattleFinishReason | null {
+    if (
+      participants.some(
+        (participant) => participant.status === "finished" || participant.progressPercent >= 100,
+      )
+    ) {
+      return "completed";
+    }
+
+    if (
+      participants.length > 0 &&
+      participants.every((participant) => participant.status === "eliminated")
+    ) {
+      return "all_eliminated";
+    }
+
+    if (this.isGameTimeExpired(currentGameState)) {
+      return "time_limit";
+    }
+
+    return null;
+  }
+
+  private rankParticipants(
+    participants: BattleParticipantState[],
+    reason: BattleFinishReason,
+  ): BattleRankingEntry[] {
+    const orderedParticipants =
+      reason === "completed"
+        ? this.rankCompletedGameParticipants(participants)
+        : reason === "all_eliminated"
+          ? [...participants].sort((left, right) => this.compareByEliminatedAtDesc(left, right))
+          : [...participants].sort((left, right) => this.compareByProgressDesc(left, right));
+
+    return orderedParticipants.map((participant, index) =>
+      this.toRankingEntry(participant, index + 1, index === 0),
+    );
+  }
+
+  private rankCompletedGameParticipants(participants: BattleParticipantState[]) {
+    const completedParticipants = participants
+      .filter(
+        (participant) => participant.status === "finished" || participant.progressPercent >= 100,
+      )
+      .sort((left, right) => this.compareByFinishedAtAsc(left, right));
+    const winner = completedParticipants[0];
+
+    if (!winner) {
+      return [...participants].sort((left, right) => this.compareByProgressDesc(left, right));
+    }
+
+    const rest = participants
+      .filter((participant) => participant.participantId !== winner.participantId)
+      .sort((left, right) => this.compareByProgressDesc(left, right));
+
+    return [winner, ...rest];
+  }
+
+  private toRankingEntry(
+    participant: BattleParticipantState,
+    rank: number,
+    isWinner: boolean,
+  ): BattleRankingEntry {
+    return {
+      acceptedLength: participant.acceptedLength,
+      accuracy: participant.accuracy,
+      eliminatedAt: participant.eliminatedAt ?? null,
+      finalStatus: this.getFinalStatus(participant, isWinner),
+      finishedAt: participant.finishedAt ?? null,
+      isWinner,
+      life: participant.life,
+      participantId: participant.participantId,
+      progressPercent: participant.progressPercent,
+      rank,
+      status: participant.status,
+      wpm: participant.wpm,
+    };
+  }
+
+  private getFinalStatus(participant: BattleParticipantState, isWinner: boolean) {
+    if (isWinner) {
+      return "winner";
+    }
+
+    if (participant.status === "finished") {
+      return "finished";
+    }
+
+    if (participant.status === "eliminated") {
+      return "eliminated";
+    }
+
+    return "playing";
+  }
+
+  private compareByFinishedAtAsc(left: BattleParticipantState, right: BattleParticipantState) {
+    return (
+      this.getTimestamp(left.finishedAt, Number.MAX_SAFE_INTEGER) -
+        this.getTimestamp(right.finishedAt, Number.MAX_SAFE_INTEGER) ||
+      this.compareByProgressDesc(left, right)
+    );
+  }
+
+  private compareByEliminatedAtDesc(left: BattleParticipantState, right: BattleParticipantState) {
+    return (
+      this.getTimestamp(right.eliminatedAt ?? right.lastInputAt, 0) -
+        this.getTimestamp(left.eliminatedAt ?? left.lastInputAt, 0) ||
+      this.compareByProgressDesc(left, right)
+    );
+  }
+
+  private compareByProgressDesc(left: BattleParticipantState, right: BattleParticipantState) {
+    return (
+      right.progressPercent - left.progressPercent ||
+      right.acceptedLength - left.acceptedLength ||
+      right.life - left.life ||
+      right.accuracy - left.accuracy ||
+      right.wpm - left.wpm ||
+      this.getTimestamp(left.lastInputAt, Number.MAX_SAFE_INTEGER) -
+        this.getTimestamp(right.lastInputAt, Number.MAX_SAFE_INTEGER) ||
+      left.participantId.localeCompare(right.participantId)
+    );
+  }
+
+  private getTimestamp(value: null | string | undefined, fallback: number) {
+    if (!value) {
+      return fallback;
+    }
+
+    const timestamp = Date.parse(value);
+
+    return Number.isNaN(timestamp) ? fallback : timestamp;
+  }
+
+  private isGameTimeExpired(currentGameState: CurrentGameState) {
+    if (!currentGameState.gameStartedAt) {
+      return false;
+    }
+
+    return (
+      Date.now() - new Date(currentGameState.gameStartedAt).getTime() >=
+      GAME_DURATION_SECONDS * 1000
+    );
   }
 
   private calculateAccuracy(acceptedLength: number, typedLength: number) {
@@ -543,6 +844,8 @@ export class BattleService {
     return {
       acceptedLength: 0,
       accuracy: 100,
+      eliminatedAt: null,
+      finishedAt: null,
       gameId: input.currentGameState.gameId,
       lastInputAt: null,
       lastPenaltyIndex: null,

--- a/apps/backend/src/modules/battle/types/battle-game-result.ts
+++ b/apps/backend/src/modules/battle/types/battle-game-result.ts
@@ -1,0 +1,28 @@
+import type { BattleParticipantStatus } from "./battle-participant-state";
+
+export type BattleFinishReason = "completed" | "all_eliminated" | "time_limit";
+
+export type BattleFinalStatus = "winner" | "finished" | "eliminated" | "playing";
+
+export type BattleRankingEntry = {
+  acceptedLength: number;
+  accuracy: number;
+  eliminatedAt: null | string;
+  finalStatus: BattleFinalStatus;
+  finishedAt: null | string;
+  isWinner: boolean;
+  life: number;
+  participantId: string;
+  progressPercent: number;
+  rank: number;
+  status: BattleParticipantStatus;
+  wpm: number;
+};
+
+export type BattleGameResult = {
+  finishedAt: string;
+  gameId: string;
+  rankings: BattleRankingEntry[];
+  reason: BattleFinishReason;
+  winnerParticipantId: null | string;
+};

--- a/apps/backend/src/modules/battle/types/battle-participant-state.ts
+++ b/apps/backend/src/modules/battle/types/battle-participant-state.ts
@@ -5,6 +5,8 @@ export type BattleParticipantStatus = "playing" | "finished" | "eliminated" | "s
 export type BattleParticipantState = {
   acceptedLength: number;
   accuracy: number;
+  eliminatedAt?: null | string;
+  finishedAt?: null | string;
   gameId: string;
   lastInputAt: null | string;
   lastPenaltyIndex: null | number;

--- a/apps/backend/src/modules/battle/types/current-game-state.ts
+++ b/apps/backend/src/modules/battle/types/current-game-state.ts
@@ -1,3 +1,4 @@
+import type { BattleFinishReason, BattleRankingEntry } from "./battle-game-result";
 import type { PromptSnapshot } from "./prompt-snapshot";
 
 export type ConnectionRole = "player" | "spectator";
@@ -8,14 +9,18 @@ export type CurrentGameState = {
   gameId: string;
   phase: GamePhase;
   createdAt: string;
+  finishReason?: BattleFinishReason | null;
   gameEndedAt: null | string;
   gameStartedAt: null | string;
   hasTenSecondNoticeSent: boolean;
   minPlayers: number;
+  nextWaitingStartsAt?: null | string;
   playerCount: number;
   prompt: PromptSnapshot;
+  rankings?: BattleRankingEntry[];
   spectatorCount: number;
   updatedAt: string;
   waitingEndsAt: null | string;
   waitingStartedAt: null | string;
+  winnerParticipantId?: null | string;
 };

--- a/apps/backend/src/modules/game-state/game-state.service.ts
+++ b/apps/backend/src/modules/game-state/game-state.service.ts
@@ -8,6 +8,7 @@ import {
 import { RedisService } from "../../storage/redis/redis.service";
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { SupabaseService } from "../../storage/supabase/supabase.service";
+import type { BattleRankingEntry } from "../battle/types/battle-game-result";
 
 // biome-ignore lint/style/useImportType: Nest DI needs a runtime class reference.
 import { MatchService } from "../match/match.service";
@@ -177,6 +178,19 @@ export class GameStateService {
 
   async getCurrentScoreboard() {
     const currentGameId = await this.redisService.instance.get("battle:current-game-id");
+    const rawGameState = await this.redisService.instance.get(`battle:game:${currentGameId}:state`);
+
+    if (rawGameState) {
+      const gameState = JSON.parse(rawGameState) as {
+        phase?: string;
+        rankings?: BattleRankingEntry[];
+      };
+
+      if (gameState.phase === "finished" && Array.isArray(gameState.rankings)) {
+        return this.getFinishedScoreboard(gameState.rankings);
+      }
+    }
+
     const rows = await this.redisService.instance.zrevrange(
       `battle:game:${currentGameId}:scoreboard`,
       0,
@@ -233,6 +247,36 @@ export class GameStateService {
     );
 
     return players.filter((p): p is NonNullable<typeof p> => p !== null);
+  }
+
+  private async getFinishedScoreboard(rankings: BattleRankingEntry[]) {
+    const players = await Promise.all(
+      rankings.map(async (ranking) => {
+        const profile = await this.redisService.instance.hgetall(
+          `lobby:player:${ranking.participantId}`,
+        );
+
+        return {
+          userId: ranking.participantId,
+          nickname: profile.nickname,
+          avatarUrl: profile.avatarUrl,
+          status: ranking.status,
+          role: "player" as const,
+          joinedAt: profile.joinedAt,
+          progressPercent: ranking.progressPercent,
+          rank: ranking.rank,
+          wpm: ranking.wpm,
+          life: ranking.life,
+          accuracy: ranking.accuracy,
+          isEliminated: ranking.status === "eliminated",
+          acceptedLength: ranking.acceptedLength,
+          finalStatus: ranking.finalStatus,
+          isWinner: ranking.isWinner,
+        };
+      }),
+    );
+
+    return players;
   }
 
   async getLatestGameResult() {

--- a/apps/backend/test/battle.gateway.spec.ts
+++ b/apps/backend/test/battle.gateway.spec.ts
@@ -191,6 +191,7 @@ describe("BattleGateway", () => {
     const buildStatePayload = jest.fn(() => statePayload);
     const battleService = {
       buildStatePayload,
+      finishCurrentGameIfNeeded: jest.fn().mockResolvedValue(null),
       unregisterConnection,
       handleDisconnectUser: jest.fn(),
     } as unknown as BattleService;

--- a/apps/backend/test/battle.input.spec.ts
+++ b/apps/backend/test/battle.input.spec.ts
@@ -292,6 +292,166 @@ describe("BattleService input validation", () => {
   });
 });
 
+describe("BattleService game finish rules", () => {
+  function createFinishService(input: {
+    currentGameState?: CurrentGameState;
+    participants: BattleParticipantState[];
+  }) {
+    const currentGameState = input.currentGameState ?? createGameState();
+    const repository = {
+      acquireGameFinishLock: jest.fn().mockResolvedValue(true),
+      getCurrentGameState: jest.fn().mockResolvedValue(currentGameState),
+      getPlayerParticipantStates: jest.fn().mockResolvedValue(input.participants),
+      saveCurrentGameState: jest.fn(),
+      saveGameResult: jest.fn(),
+    } as unknown as BattleStateRepository;
+
+    return {
+      repository,
+      service: new BattleService(repository, {} as PromptRepository),
+    };
+  }
+
+  it("finishes when a player reaches 100 percent and ranks the rest by progress", async () => {
+    const { repository, service } = createFinishService({
+      participants: [
+        createParticipantState({
+          acceptedLength: 5,
+          finishedAt: "2026-05-06T00:02:00.000Z",
+          participantId: "user-1",
+          progressPercent: 100,
+          status: "finished",
+        }),
+        createParticipantState({
+          acceptedLength: 2,
+          participantId: "user-2",
+          progressPercent: 40,
+        }),
+        createParticipantState({
+          acceptedLength: 4,
+          participantId: "user-3",
+          progressPercent: 80,
+        }),
+      ],
+    });
+
+    const result = await service.finishCurrentGameIfNeeded();
+
+    expect(result?.result).toMatchObject({
+      reason: "completed",
+      winnerParticipantId: "user-1",
+      rankings: [
+        expect.objectContaining({ isWinner: true, participantId: "user-1", rank: 1 }),
+        expect.objectContaining({ participantId: "user-3", rank: 2 }),
+        expect.objectContaining({ participantId: "user-2", rank: 3 }),
+      ],
+    });
+    expect(repository.saveCurrentGameState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "finished",
+        finishReason: "completed",
+        winnerParticipantId: "user-1",
+        nextWaitingStartsAt: expect.any(String),
+      }),
+    );
+    expect(repository.saveGameResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "completed",
+        winnerParticipantId: "user-1",
+      }),
+    );
+  });
+
+  it("finishes when all players are eliminated and ranks by last elimination", async () => {
+    const { service } = createFinishService({
+      participants: [
+        createParticipantState({
+          eliminatedAt: "2026-05-06T00:03:00.000Z",
+          participantId: "user-1",
+          status: "eliminated",
+        }),
+        createParticipantState({
+          eliminatedAt: "2026-05-06T00:05:00.000Z",
+          participantId: "user-2",
+          status: "eliminated",
+        }),
+        createParticipantState({
+          eliminatedAt: "2026-05-06T00:04:00.000Z",
+          participantId: "user-3",
+          status: "eliminated",
+        }),
+      ],
+    });
+
+    const result = await service.finishCurrentGameIfNeeded();
+
+    expect(result?.result).toMatchObject({
+      reason: "all_eliminated",
+      winnerParticipantId: "user-2",
+      rankings: [
+        expect.objectContaining({ finalStatus: "winner", participantId: "user-2", rank: 1 }),
+        expect.objectContaining({ finalStatus: "eliminated", participantId: "user-3", rank: 2 }),
+        expect.objectContaining({ finalStatus: "eliminated", participantId: "user-1", rank: 3 }),
+      ],
+    });
+  });
+
+  it("finishes after the 15 minute time limit and ranks by progress", async () => {
+    const startedAt = new Date(Date.now() - 15 * 60 * 1000 - 1000).toISOString();
+    const { service } = createFinishService({
+      currentGameState: createGameState({
+        gameStartedAt: startedAt,
+      }),
+      participants: [
+        createParticipantState({
+          acceptedLength: 1,
+          participantId: "user-1",
+          progressPercent: 20,
+        }),
+        createParticipantState({
+          acceptedLength: 4,
+          participantId: "user-2",
+          progressPercent: 80,
+        }),
+      ],
+    });
+
+    const result = await service.finishCurrentGameIfNeeded();
+
+    expect(result?.result).toMatchObject({
+      reason: "time_limit",
+      winnerParticipantId: "user-2",
+      rankings: [
+        expect.objectContaining({ participantId: "user-2", rank: 1 }),
+        expect.objectContaining({ participantId: "user-1", rank: 2 }),
+      ],
+    });
+  });
+
+  it("opens a new waiting game only after the 30 second finished delay", async () => {
+    const finishedGameState = createGameState({
+      gameEndedAt: "2026-05-06T00:16:00.000Z",
+      nextWaitingStartsAt: new Date(Date.now() - 1000).toISOString(),
+      phase: "finished",
+    });
+    const repository = {
+      saveCurrentGameState: jest.fn(),
+    } as unknown as BattleStateRepository;
+    const promptRepository = {
+      getRandomPrompt: jest.fn().mockResolvedValue(prompt),
+    } as unknown as PromptRepository;
+    const service = new BattleService(repository, promptRepository);
+
+    const nextGameState = await service.startNextWaitingGameIfReady(finishedGameState);
+
+    expect(nextGameState).toMatchObject({
+      phase: "waiting",
+      waitingEndsAt: expect.any(String),
+    });
+    expect(repository.saveCurrentGameState).toHaveBeenCalledWith(nextGameState);
+  });
+});
+
 describe("BattleGateway input handling", () => {
   it("broadcasts progress after accepted input", async () => {
     const participant = createParticipantState({
@@ -307,7 +467,10 @@ describe("BattleGateway input handling", () => {
       ok: true,
     });
     const gateway = new BattleGateway(
-      { validateInput } as unknown as BattleService,
+      {
+        finishCurrentGameIfNeeded: jest.fn().mockResolvedValue(null),
+        validateInput,
+      } as unknown as BattleService,
       {} as BattleBroadcastService,
     );
     const { emit, server, to } = createServer();
@@ -353,7 +516,10 @@ describe("BattleGateway input handling", () => {
       ok: true,
     });
     const gateway = new BattleGateway(
-      { validateInput } as unknown as BattleService,
+      {
+        finishCurrentGameIfNeeded: jest.fn().mockResolvedValue(null),
+        validateInput,
+      } as unknown as BattleService,
       {} as BattleBroadcastService,
     );
     const { emit, server } = createServer();


### PR DESCRIPTION
## 작업 내용
- 게임 종료 로직 추가

## 상세 변경 사항
- 게임 종료 조건 추가
  - 플레이어 1명이라도 prompt를 100% 완성하면 종료
  - 모든 플레이어가 탈락하면 종료
  - 게임 시작 후 15분이 지나면 종료

- 종료 조건별 랭킹 계산 추가
  - 100% 완성 시: 완성한 플레이어가 우승, 나머지는 진행도순
  - 전원 탈락 시: 가장 늦게 탈락한 플레이어가 우승, 나머지는 늦게 탈락한 순
  - 제한 시간 초과 시: 진행도순

- 최종 결과 스냅샷 저장
  - `finishReason`
  - `winnerParticipantId`
  - `rankings`
  - `nextWaitingStartsAt`

- Socket 이벤트 흐름 보강
  - 입력/탈락/연결 해제 직후 종료 조건 검사
  - 종료 시 `battle:finished`, `battle:state` 브로드캐스트

- 게임 사이클 타이머 보강
  - 진행 중 게임의 15분 제한 시간 검사
  - finished 상태에서 30초 후 새 waiting 게임 생성

- finished 상태의 scoreboard 조회가 실시간 점수판이 아니라 최종 ranking을 반환하도록 수정

## 관련 이슈
- closes #

## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?