### PR TITLE
[feat] 구현: 게임 소켓 연결 및 대기 상태 연동

### DIFF
--- a/apps/frontend/src/api/match.api.ts
+++ b/apps/frontend/src/api/match.api.ts
@@ -1,0 +1,11 @@
+import { api } from "@/lib/api";
+
+type JoinMatchResponse = {
+  socketAuthToken: string;
+};
+
+export const joinMatch = async () => {
+  const { data } = await api.post<JoinMatchResponse>("/v1/match/join");
+
+  return data;
+};

--- a/apps/frontend/src/lib/socket/battleSocket.ts
+++ b/apps/frontend/src/lib/socket/battleSocket.ts
@@ -1,9 +1,9 @@
 import { io, type Socket } from "socket.io-client";
 
-const SERVER_URL = import.meta.env.VITE_SERVER_URL;
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL;
 
 export const createBattleSocket = (socketAuthToken: string): Socket => {
-  return io(`${SERVER_URL}/battle`, {
+  return io(`${SOCKET_URL}/battle`, {
     auth: {
       token: socketAuthToken,
     },

--- a/apps/frontend/src/pages/GamePage.tsx
+++ b/apps/frontend/src/pages/GamePage.tsx
@@ -11,12 +11,22 @@ import { PATH } from "@/constants/route";
 import { createBattleSocket } from "@/lib/socket/battleSocket";
 import { BATTLE_SOCKET_EVENTS } from "@/lib/socket/socketEvents";
 
+const REFRESH_TOKEN_COOKIE_ERROR_MESSAGE = "게스트 로그인에 실패했습니다.";
+const MATCH_JOIN_ERROR_MESSAGE = "매치 참가에 실패했습니다.";
+
 const MOCK_PROMPT = `동해물과 백두산이 마르고 닳도록
 하느님이 보우하사 우리 나라 만세
 무궁화 삼천리 화려강산
 대한사람 대한으로 길이 보전하세`;
 
 type GamePhase = "waiting" | "countdown" | "playing";
+
+type JoinMatchResponse = {
+  socketAuthToken?: string;
+  data?: {
+    socketAuthToken?: string;
+  };
+};
 
 const getPromptLength = (prompt: string) => {
   return prompt.replaceAll("\n", "").length;
@@ -38,6 +48,10 @@ const formatWaitingTime = (seconds: number) => {
   }
 
   return `${remainSeconds}초`;
+};
+
+const getApiBaseUrl = () => {
+  return import.meta.env.VITE_API_BASE_URL;
 };
 
 const GamePage = () => {
@@ -74,7 +88,6 @@ const GamePage = () => {
         if (prev <= 1) {
           window.clearInterval(timer);
           setPhase("countdown");
-
           return 0;
         }
 
@@ -96,7 +109,6 @@ const GamePage = () => {
           window.clearInterval(timer);
           setPhase("playing");
           setElapsedSeconds(0);
-
           return 0;
         }
 
@@ -110,59 +122,116 @@ const GamePage = () => {
   }, [phase]);
 
   useEffect(() => {
-    const socketAuthToken = "ws_tk_xxx";
+    const connectBattleSocket = async () => {
+      try {
+        const apiBaseUrl = getApiBaseUrl();
 
-    const socket = createBattleSocket(socketAuthToken);
-    socketRef.current = socket;
+        const loginResponse = await fetch(`${apiBaseUrl}/v1/auth/guest/login`, {
+          method: "POST",
+          credentials: "include",
+        });
 
-    socket.on(BATTLE_SOCKET_EVENTS.WELCOME, (data) => {
-      console.log("소켓 연결 성공:", data);
-    });
+        if (!loginResponse.ok) {
+          throw new Error(REFRESH_TOKEN_COOKIE_ERROR_MESSAGE);
+        }
 
-    socket.on(BATTLE_SOCKET_EVENTS.ERROR, (error) => {
-      console.error("소켓 에러:", error);
-    });
+        const loginData = await loginResponse.json();
 
-    socket.on(BATTLE_SOCKET_EVENTS.STATE, (data) => {
-      console.log("현재 게임 상태:", data);
-    });
+        const accessToken =
+          loginData.tokens?.accessToken ??
+          loginData.data?.tokens?.accessToken ??
+          loginData.accessToken;
 
-    socket.on(BATTLE_SOCKET_EVENTS.WAITING, (data) => {
-      console.log("게임 대기 중:", data);
-    });
+        if (!accessToken) {
+          throw new Error("accessToken이 없습니다.");
+        }
+        const joinResponse = await fetch(`${apiBaseUrl}/v1/match/join`, {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
 
-    socket.on(BATTLE_SOCKET_EVENTS.STARTED, (data) => {
-      console.log("게임 시작:", data);
+        if (!joinResponse.ok) {
+          throw new Error(MATCH_JOIN_ERROR_MESSAGE);
+        }
 
-      setPromptContent(data.prompt.content);
-      setElapsedSeconds(0);
-      setTypingCount(0);
-      setAccuracy(100);
-      setProgress(0);
-      setLife(3);
-      setPhase("playing");
-    });
+        const joinData = (await joinResponse.json()) as JoinMatchResponse;
+        const socketAuthToken = joinData.socketAuthToken ?? joinData.data?.socketAuthToken;
 
-    socket.on(BATTLE_SOCKET_EVENTS.PROGRESS, (data) => {
-      console.log("진행 상황:", data);
+        if (!socketAuthToken) {
+          throw new Error("socketAuthToken이 없습니다.");
+        }
 
-      setProgress(data.participant.progressPercent);
-      setTypingCount(data.participant.acceptedLength);
-      setAccuracy(data.participant.accuracy);
-      setLife(data.participant.life);
-    });
+        const socket = createBattleSocket(socketAuthToken);
+        socketRef.current = socket;
 
-    socket.on(BATTLE_SOCKET_EVENTS.ELIMINATED, (data) => {
-      console.log("탈락:", data);
-      setLife(0);
-    });
+        socket.on(BATTLE_SOCKET_EVENTS.WELCOME, (data) => {
+          console.log("소켓 연결 성공:", data);
+        });
 
-    socket.on(BATTLE_SOCKET_EVENTS.FINISHED, (data) => {
-      console.log("게임 종료:", data);
-    });
+        socket.on(BATTLE_SOCKET_EVENTS.ERROR, (error) => {
+          console.error("소켓 에러:", error);
+        });
+
+        socket.on(BATTLE_SOCKET_EVENTS.STATE, (data) => {
+          console.log("현재 게임 상태:", data);
+        });
+
+        socket.on(BATTLE_SOCKET_EVENTS.WAITING, (data) => {
+          console.log("게임 대기 중:", data);
+
+          const remainingSeconds = data.remainingSeconds ?? 15;
+
+          if (remainingSeconds <= 10) {
+            setPhase("countdown");
+            setCountdown(remainingSeconds);
+            return;
+          }
+
+          setPhase("waiting");
+          setWaitingSeconds(remainingSeconds);
+        });
+
+        socket.on(BATTLE_SOCKET_EVENTS.STARTED, (data) => {
+          console.log("게임 시작:", data);
+
+          setPromptContent(data.prompt?.content ?? MOCK_PROMPT);
+          setElapsedSeconds(0);
+          setTypingCount(0);
+          setAccuracy(100);
+          setProgress(0);
+          setLife(3);
+          setPhase("playing");
+        });
+
+        socket.on(BATTLE_SOCKET_EVENTS.PROGRESS, (data) => {
+          console.log("진행 상황:", data);
+
+          setProgress(data.participant?.progressPercent ?? 0);
+          setTypingCount(data.participant?.acceptedLength ?? 0);
+          setAccuracy(data.participant?.accuracy ?? 100);
+          setLife(data.participant?.life ?? 3);
+        });
+
+        socket.on(BATTLE_SOCKET_EVENTS.ELIMINATED, (data) => {
+          console.log("탈락:", data);
+          setLife(0);
+        });
+
+        socket.on(BATTLE_SOCKET_EVENTS.FINISHED, (data) => {
+          console.log("게임 종료:", data);
+        });
+      } catch (error) {
+        console.error("소켓 연결 준비 실패:", error);
+      }
+    };
+
+    connectBattleSocket();
 
     return () => {
-      socket.disconnect();
+      socketRef.current?.disconnect();
       socketRef.current = null;
     };
   }, []);
@@ -210,51 +279,52 @@ const GamePage = () => {
         <Settings size={47} strokeWidth={2.5} className="text-[#3F3F3F]" />
       </Link>
 
-      <div className="flex h-full w-full gap-8 px-8 py-6">
-        <div className="w-[260px] shrink-0">
-          <SideBar mode={isPlaying ? "game" : "waiting"} />
-        </div>
+      <div className="h-full w-full p-6">
+        <div className="flex h-full w-full gap-8 overflow-hidden">
+          <div className="w-[260px] shrink-0">
+            <SideBar mode={isPlaying ? "game" : "waiting"} />
+          </div>
 
-        <div className="flex min-w-0 flex-1 justify-center overflow-hidden">
-          <div className="w-full max-w-[1180px]">
-            <div className="flex w-full flex-col items-center gap-6">
-              {isPlaying ? (
-                <RaceTrack progress={progress} />
-              ) : (
-                <div className="flex h-[87px] w-full max-w-[900px] items-center justify-center text-center text-[clamp(28px,3vw,44px)] font-bold text-white drop-shadow-[3px_3px_0px_#000]">
-                  {phase === "waiting" ? "게임 진입까지 " : "게임 시작까지 "}
+          <div className="flex min-w-0 flex-1 justify-center overflow-hidden">
+            <div className="w-full max-w-[1180px]">
+              <div className="flex w-full flex-col items-center gap-6">
+                {isPlaying ? (
+                  <RaceTrack progress={progress} />
+                ) : (
+                  <div className="flex h-[87px] w-full max-w-[900px] items-center justify-center text-center text-[clamp(28px,3vw,44px)] font-bold text-white drop-shadow-[3px_3px_0px_#000]">
+                    {phase === "waiting" ? "게임 진입까지 " : "게임 시작까지 "}
+                    <span className="text-yellow-400">
+                      {phase === "waiting" ? formatWaitingTime(waitingSeconds) : `${countdown}초`}
+                    </span>
+                  </div>
+                )}
 
-                  <span className="text-yellow-400">
-                    {phase === "waiting" ? formatWaitingTime(waitingSeconds) : `${countdown}초`}
-                  </span>
-                </div>
-              )}
-
-              <GameProgress
-                typingCount={typingCount}
-                accuracy={accuracy}
-                time={isPlaying ? formatTime(elapsedSeconds) : "01:14"}
-                isWaiting={!isPlaying}
-              />
-
-              {phase === "waiting" && <PracticeBox />}
-
-              {phase === "countdown" && (
-                <div className="flex h-[clamp(300px,52vh,420px)] w-full max-w-[916px] items-center justify-center border-[4px] border-black bg-[#454545] shadow-[8px_8px_0px_#000]">
-                  <span className="text-[clamp(80px,12vw,140px)] font-bold text-white drop-shadow-[4px_4px_0px_#000]">
-                    {countdown}
-                  </span>
-                </div>
-              )}
-
-              {phase === "playing" && (
-                <TypingGame
-                  prompt={promptContent}
-                  life={life}
-                  onInputChange={handleInputChange}
-                  onWrongInput={handleWrongInput}
+                <GameProgress
+                  typingCount={typingCount}
+                  accuracy={accuracy}
+                  time={isPlaying ? formatTime(elapsedSeconds) : "01:14"}
+                  isWaiting={!isPlaying}
                 />
-              )}
+
+                {phase === "waiting" && <PracticeBox />}
+
+                {phase === "countdown" && (
+                  <div className="flex h-[clamp(300px,52vh,420px)] w-full max-w-[916px] items-center justify-center border-[4px] border-black bg-[#454545] shadow-[8px_8px_0px_#000]">
+                    <span className="text-[clamp(80px,12vw,140px)] font-bold text-white drop-shadow-[4px_4px_0px_#000]">
+                      {countdown}
+                    </span>
+                  </div>
+                )}
+
+                {phase === "playing" && (
+                  <TypingGame
+                    prompt={promptContent}
+                    life={life}
+                    onInputChange={handleInputChange}
+                    onWrongInput={handleWrongInput}
+                  />
+                )}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 작업 내용
- 게스트 로그인 API 연동
- match join API 연동
- socketAuthToken 기반 소켓 연결 구현
- WAITING 이벤트 수신 처리
- countdown 상태 UI 연동
- 게임 phase 상태 관리 추가
  - waiting
  - countdown
  - playing
- STARTED / PROGRESS / FINISHED 이벤트 핸들러 추가
- 소켓 disconnect cleanup 처리
<img width="1900" height="983" alt="image" src="https://github.com/user-attachments/assets/3662c612-b46d-4cd1-814a-93cc039b77e6" />

## 상세 변경 사항
- GamePage 실시간 상태 동기화 구현
- 서버 remainingSeconds 기반 카운트다운 표시
- 소켓 이벤트 기반 게임 상태 관리 추가

## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?
```
