### PR TITLE
test: match, games API 테스트 추가

### DIFF
--- a/apps/backend/test/games.spec.ts
+++ b/apps/backend/test/games.spec.ts
@@ -1,0 +1,114 @@
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { GamesController } from "../src/modules/games/games.controller";
+import { GamesService } from "../src/modules/games/games.service";
+
+const mockGamesService = {
+  getCurrentGame: jest.fn(),
+  getCurrentScoreboard: jest.fn(),
+  getCurrentSpectators: jest.fn(),
+  getLatestGameResult: jest.fn(),
+};
+
+describe("Games API", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [GamesController],
+      providers: [
+        {
+          provide: GamesService,
+          useValue: mockGamesService,
+        },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const getRequest = () => request(app.getHttpAdapter().getInstance());
+
+  describe("GET /v1/games/current", () => {
+    it("현재 게임 상태를 반환한다", async () => {
+      const currentGame = {
+        gameId: "game-123",
+        phase: "waiting",
+        startedAt: "2026-05-11T00:00:00.000Z",
+      };
+      mockGamesService.getCurrentGame.mockResolvedValue(currentGame);
+
+      const response = await getRequest().get("/v1/games/current").expect(200);
+
+      expect(mockGamesService.getCurrentGame).toHaveBeenCalledTimes(1);
+      expect(response.body).toEqual(currentGame);
+    });
+  });
+
+  describe("GET /v1/games/current/scoreboard", () => {
+    it("현재 스코어보드를 반환한다", async () => {
+      const scoreboard = {
+        gameId: "game-123",
+        players: [
+          { userId: "user-1", nickname: "Jay", rank: 1, progress: 92 },
+          { userId: "user-2", nickname: "Mia", rank: 2, progress: 81 },
+        ],
+      };
+      mockGamesService.getCurrentScoreboard.mockResolvedValue(scoreboard);
+
+      const response = await getRequest().get("/v1/games/current/scoreboard").expect(200);
+
+      expect(mockGamesService.getCurrentScoreboard).toHaveBeenCalledTimes(1);
+      expect(response.body).toEqual(scoreboard);
+    });
+  });
+
+  describe("GET /v1/games/current/spectators", () => {
+    it("현재 관전자 목록을 반환한다", async () => {
+      const spectators = [
+        {
+          userId: "user-3",
+          nickname: "Noah",
+          avatarUrl: "https://example.com/noah.png",
+        },
+        {
+          userId: "user-4",
+          nickname: "Luna",
+          avatarUrl: "https://example.com/luna.png",
+        },
+      ];
+      mockGamesService.getCurrentSpectators.mockResolvedValue(spectators);
+
+      const response = await getRequest().get("/v1/games/current/spectators").expect(200);
+
+      expect(mockGamesService.getCurrentSpectators).toHaveBeenCalledTimes(1);
+      expect(response.body).toEqual(spectators);
+    });
+  });
+
+  describe("GET /v1/games/current/result", () => {
+    it("가장 최근 게임 결과를 반환한다", async () => {
+      const result = {
+        gameId: "game-122",
+        winnerUserId: "user-1",
+        finishedAt: "2026-05-11T00:10:00.000Z",
+      };
+      mockGamesService.getLatestGameResult.mockResolvedValue(result);
+
+      const response = await getRequest().get("/v1/games/current/result").expect(200);
+
+      expect(mockGamesService.getLatestGameResult).toHaveBeenCalledTimes(1);
+      expect(response.body).toEqual(result);
+    });
+  });
+});

--- a/apps/backend/test/match.spec.ts
+++ b/apps/backend/test/match.spec.ts
@@ -1,0 +1,137 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  type INestApplication,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { JwtAuthGuard } from "../src/modules/auth/guards/jwt-auth.guard";
+import { MatchController } from "../src/modules/match/match.controller";
+import { MatchService } from "../src/modules/match/match.service";
+
+const mockMatchService = {
+  joinGame: jest.fn(),
+  getAllUsers: jest.fn(),
+};
+
+class MockJwtAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    request.user = {
+      id: "auth-user-123",
+    };
+    return true;
+  }
+}
+
+class RejectJwtAuthGuard implements CanActivate {
+  canActivate(_: ExecutionContext): boolean {
+    throw new UnauthorizedException();
+  }
+}
+
+describe("Match API", () => {
+  let app: INestApplication;
+  let unauthorizedApp: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [MatchController],
+      providers: [
+        {
+          provide: MatchService,
+          useValue: mockMatchService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useClass(MockJwtAuthGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const unauthorizedModuleRef = await Test.createTestingModule({
+      controllers: [MatchController],
+      providers: [
+        {
+          provide: MatchService,
+          useValue: mockMatchService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useClass(RejectJwtAuthGuard)
+      .compile();
+
+    unauthorizedApp = unauthorizedModuleRef.createNestApplication();
+    await unauthorizedApp.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await unauthorizedApp.close();
+  });
+
+  const getRequest = () => request(app.getHttpAdapter().getInstance());
+  const getUnauthorizedRequest = () => request(unauthorizedApp.getHttpAdapter().getInstance());
+
+  describe("POST /v1/match/join", () => {
+    it("인증된 사용자를 매치에 참여시킨다", async () => {
+      const payload = {
+        userId: "auth-user-123",
+        role: "player",
+        status: "waiting",
+        socketNamespace: "/battle",
+        socketAuthToken: "ws_tk_test-token",
+      };
+      mockMatchService.joinGame.mockResolvedValue(payload);
+
+      const response = await getRequest().post("/v1/match/join").expect(201);
+
+      expect(mockMatchService.joinGame).toHaveBeenCalledTimes(1);
+      expect(mockMatchService.joinGame).toHaveBeenCalledWith("auth-user-123");
+      expect(response.body).toEqual(payload);
+    });
+
+    it("인증되지 않은 요청이면 401을 반환한다", async () => {
+      await getUnauthorizedRequest().post("/v1/match/join").expect(401);
+
+      expect(mockMatchService.joinGame).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /v1/match/users", () => {
+    it("대기실 유저 목록을 반환한다", async () => {
+      const players = [
+        {
+          userId: "user-1",
+          nickname: "Jay",
+          avatarUrl: "https://example.com/jay.png",
+          status: "waiting",
+          role: "player",
+          joinedAt: "2026-05-11T00:00:00.000Z",
+        },
+        {
+          userId: "user-2",
+          nickname: "Mia",
+          avatarUrl: "https://example.com/mia.png",
+          status: "spectating",
+          role: "spectator",
+          joinedAt: "2026-05-11T00:01:00.000Z",
+        },
+      ];
+      mockMatchService.getAllUsers.mockResolvedValue(players);
+
+      const response = await getRequest().get("/v1/match/users").expect(200);
+
+      expect(mockMatchService.getAllUsers).toHaveBeenCalledTimes(1);
+      expect(response.body).toEqual(players);
+    });
+  });
+});


### PR DESCRIPTION
## 작업 내용
- `match` API와 `games` API에 대한 컨트롤러/HTTP 레벨 테스트 코드를 추가했습니다.

## 상세 변경 사항
- `apps/backend/test/match.spec.ts`를 추가하고 `POST /v1/match/join`, `GET /v1/match/users`에 대한 테스트를 작성했습니다.
- `POST /v1/match/join` 엔드포인트에 대해 인증 실패 시 `401`을 반환하는 케이스를 추가했습니다.
- `apps/backend/test/games.spec.ts`를 추가하고 `GET /v1/games/current`, `GET /v1/games/current/scoreboard`, `GET /v1/games/current/spectators`, `GET /v1/games/current/result` 테스트를 작성했습니다.

## 관련 이슈
- closes #23

## 체크리스트
- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료헀나요?
