### PR TITLE
[feat] 게임 대기 로직 구현: 최소 인원 조건 및 이전 게임 정보 표시

### DIFF
--- a/apps/frontend/src/components/game/GameProgress/GameProgress.tsx
+++ b/apps/frontend/src/components/game/GameProgress/GameProgress.tsx
@@ -24,8 +24,8 @@ export default function GameProgress({
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 md:gap-6">
         {isWaiting ? (
           <>
-            <StatusItem label="우승자" value="닉네임1" color="text-yellow-400" />
-            <StatusItem label="참여자" value={25} unit="명" color="text-cyan-400" />
+            <StatusItem label="우승자" value={accuracy} color="text-yellow-400" />
+            <StatusItem label="참여자" value={typingCount} unit="명" color="text-cyan-400" />
             <StatusItem label="시간" value={time} color="text-emerald-400" />
           </>
         ) : (

--- a/apps/frontend/src/pages/GamePage.tsx
+++ b/apps/frontend/src/pages/GamePage.tsx
@@ -1,5 +1,5 @@
 import { Settings } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import type { Socket } from "socket.io-client";
 import SideBar from "@/components/common/Sidebar/SideBar";
@@ -13,7 +13,7 @@ import { BATTLE_SOCKET_EVENTS } from "@/lib/socket/socketEvents";
 
 const REFRESH_TOKEN_COOKIE_ERROR_MESSAGE = "게스트 로그인에 실패했습니다.";
 const MATCH_JOIN_ERROR_MESSAGE = "매치 참가에 실패했습니다.";
-
+const MIN_PLAYERS = 4;
 const MOCK_PROMPT = `동해물과 백두산이 마르고 닳도록
 하느님이 보우하사 우리 나라 만세
 무궁화 삼천리 화려강산
@@ -50,16 +50,29 @@ const formatWaitingTime = (seconds: number) => {
   return `${remainSeconds}초`;
 };
 
+const getDurationSeconds = (startedAt?: string, endedAt?: string) => {
+  if (!startedAt || !endedAt) return 0;
+
+  const durationMs = new Date(endedAt).getTime() - new Date(startedAt).getTime();
+
+  return Math.max(0, Math.floor(durationMs / 1000));
+};
+
 const getApiBaseUrl = () => {
   return import.meta.env.VITE_API_BASE_URL;
 };
 
 const GamePage = () => {
   const socketRef = useRef<Socket | null>(null);
+  const isEnoughPlayersRef = useRef(false);
 
   const [phase, setPhase] = useState<GamePhase>("waiting");
-  const [waitingSeconds, setWaitingSeconds] = useState(15);
+  const [waitingSeconds, setWaitingSeconds] = useState(0);
   const [countdown, setCountdown] = useState(10);
+
+  const [previousWinner, setPreviousWinner] = useState("-");
+  const [waitingPlayerCount, setWaitingPlayerCount] = useState(0);
+  const [previousGameDuration, setPreviousGameDuration] = useState("00:00");
 
   const [promptContent, setPromptContent] = useState(MOCK_PROMPT);
   const [progress, setProgress] = useState(0);
@@ -67,6 +80,15 @@ const GamePage = () => {
   const [accuracy, setAccuracy] = useState(100);
   const [life, setLife] = useState(3);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  const updatePlayerStatus = useCallback((playerCount: number, minPlayers: number) => {
+    const hasEnoughPlayers = playerCount >= minPlayers;
+
+    isEnoughPlayersRef.current = hasEnoughPlayers;
+    setWaitingPlayerCount(playerCount);
+
+    return hasEnoughPlayers;
+  }, []);
 
   useEffect(() => {
     if (phase !== "playing") return;
@@ -81,32 +103,21 @@ const GamePage = () => {
   }, [phase]);
 
   useEffect(() => {
-    if (phase !== "waiting") return;
-
-    const timer = window.setInterval(() => {
-      setWaitingSeconds((prev) => {
-        if (prev <= 1) {
-          window.clearInterval(timer);
-          setPhase("countdown");
-          return 0;
-        }
-
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [phase]);
-
-  useEffect(() => {
     if (phase !== "countdown") return;
 
     const timer = window.setInterval(() => {
       setCountdown((prev) => {
         if (prev <= 1) {
           window.clearInterval(timer);
+
+          if (!isEnoughPlayersRef.current) {
+            setPhase("waiting");
+            setCountdown(10);
+            setWaitingSeconds(0);
+
+            return prev;
+          }
+
           setPhase("playing");
           setElapsedSeconds(0);
           return 0;
@@ -145,6 +156,7 @@ const GamePage = () => {
         if (!accessToken) {
           throw new Error("accessToken이 없습니다.");
         }
+
         const joinResponse = await fetch(`${apiBaseUrl}/v1/match/join`, {
           method: "POST",
           credentials: "include",
@@ -177,12 +189,48 @@ const GamePage = () => {
 
         socket.on(BATTLE_SOCKET_EVENTS.STATE, (data) => {
           console.log("현재 게임 상태:", data);
+
+          const playerCount = data.game?.playerCount ?? data.playerCount ?? 0;
+          const minPlayers = data.game?.minPlayers ?? data.minPlayers ?? MIN_PLAYERS;
+
+          updatePlayerStatus(playerCount, minPlayers);
+
+          const winner =
+            data.previousGame?.winner?.nickname ??
+            data.previousGame?.winnerName ??
+            data.previousGame?.winner ??
+            "-";
+
+          setPreviousWinner(winner);
+
+          const startedAt =
+            data.previousGame?.gameStartedAt ??
+            data.previousGame?.startedAt ??
+            data.game?.gameStartedAt;
+
+          const endedAt =
+            data.previousGame?.gameEndedAt ?? data.previousGame?.endedAt ?? data.game?.gameEndedAt;
+
+          setPreviousGameDuration(formatTime(getDurationSeconds(startedAt, endedAt)));
         });
 
         socket.on(BATTLE_SOCKET_EVENTS.WAITING, (data) => {
           console.log("게임 대기 중:", data);
 
+          const playerCount = data.game?.playerCount ?? data.playerCount ?? 0;
+          const minPlayers = data.game?.minPlayers ?? data.minPlayers ?? MIN_PLAYERS;
+          const hasEnoughPlayers = updatePlayerStatus(playerCount, minPlayers);
+
+          if (!hasEnoughPlayers) {
+            setPhase("waiting");
+            setWaitingSeconds(0);
+            setCountdown(10);
+            return;
+          }
+
           const remainingSeconds = data.remainingSeconds ?? 15;
+
+          setWaitingSeconds(remainingSeconds);
 
           if (remainingSeconds <= 10) {
             setPhase("countdown");
@@ -191,11 +239,18 @@ const GamePage = () => {
           }
 
           setPhase("waiting");
-          setWaitingSeconds(remainingSeconds);
         });
 
         socket.on(BATTLE_SOCKET_EVENTS.STARTED, (data) => {
           console.log("게임 시작:", data);
+
+          if (!isEnoughPlayersRef.current) {
+            console.warn("최소 인원 미달로 STARTED 이벤트 무시");
+            setPhase("waiting");
+            setWaitingSeconds(0);
+            setCountdown(10);
+            return;
+          }
 
           setPromptContent(data.prompt?.content ?? MOCK_PROMPT);
           setElapsedSeconds(0);
@@ -234,7 +289,7 @@ const GamePage = () => {
       socketRef.current?.disconnect();
       socketRef.current = null;
     };
-  }, []);
+  }, [updatePlayerStatus]);
 
   const handleInputChange = (
     inputText: string,
@@ -292,17 +347,25 @@ const GamePage = () => {
                   <RaceTrack progress={progress} />
                 ) : (
                   <div className="flex h-[87px] w-full max-w-[900px] items-center justify-center text-center text-[clamp(28px,3vw,44px)] font-bold text-white drop-shadow-[3px_3px_0px_#000]">
-                    {phase === "waiting" ? "게임 진입까지 " : "게임 시작까지 "}
-                    <span className="text-yellow-400">
-                      {phase === "waiting" ? formatWaitingTime(waitingSeconds) : `${countdown}초`}
-                    </span>
+                    {waitingPlayerCount < MIN_PLAYERS ? (
+                      <span className="text-yellow-400">참여자를 기다리는 중...</span>
+                    ) : (
+                      <>
+                        {phase === "waiting" ? "게임 진입까지 " : "게임 시작까지 "}
+                        <span className="text-yellow-400">
+                          {phase === "waiting"
+                            ? formatWaitingTime(waitingSeconds)
+                            : `${countdown}초`}
+                        </span>
+                      </>
+                    )}
                   </div>
                 )}
 
                 <GameProgress
-                  typingCount={typingCount}
-                  accuracy={accuracy}
-                  time={isPlaying ? formatTime(elapsedSeconds) : "01:14"}
+                  typingCount={isPlaying ? typingCount : waitingPlayerCount}
+                  accuracy={isPlaying ? accuracy : previousWinner}
+                  time={isPlaying ? formatTime(elapsedSeconds) : previousGameDuration}
                   isWaiting={!isPlaying}
                 />
 

--- a/apps/frontend/src/types/game/progress.ts
+++ b/apps/frontend/src/types/game/progress.ts
@@ -1,6 +1,6 @@
 export type GameProgressProps = {
   typingCount: number;
-  accuracy: number;
+  accuracy: number | string;
   time: string;
   isWaiting?: boolean;
 };


### PR DESCRIPTION
##  개요

게임 대기 화면 로직을 개선했습니다.

- 최소 참여 인원 조건 추가
- 이전 게임 정보 표시
- 최소 인원 미달 시 게임 시작 방지 처리

---

##  작업 내용

- 이전 게임 우승자 표시 기능 추가
- 이전 게임 플레이 시간 표시 기능 추가
- 현재 참여자 수 표시 기능 추가
- 게임 대기 상태 UI 개선
- 최소 참여 인원 미달 시 카운트다운 비활성화
- 최소 인원 미달 상태에서 STARTED 이벤트 방어 처리
- waiting 상태 로컬 interval 제거
- 서버 remainingSeconds 기반 countdown 처리

---

## 변경 사항

### 게임 대기 화면

- `우승자`
- `참여자`
- `시간`

정보가 동적으로 표시되도록 수정했습니다.

### 최소 인원 로직

- 최소 인원 미달 시:
  - `참여자를 기다리는 중...` 문구 표시
  - countdown 진행 방지
  - STARTED 이벤트 무시 처리

### 상태 관리 개선

- `MIN_PLAYERS` 상수 분리
- `isEnoughPlayersRef` 기반 최신 상태 추적
- waiting countdown 로직 정리

---

##  UI 스크린샷

### 최소 인원 미달 상태

- 참여자를 기다리는 중... 화면 표시

### 최소 인원 충족 상태

- 게임 countdown 정상 진행

---

## 체크리스트

- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료했나요?