### PR TITLE
[style] 다크모드 적용: 게임 화면 색상 토큰 리팩토링

### DIFF
--- a/apps/frontend/src/components/game/GameProgress/GameProgress.tsx
+++ b/apps/frontend/src/components/game/GameProgress/GameProgress.tsx
@@ -2,10 +2,10 @@ import type { GameProgressProps, StatusItemProps } from "@/types";
 
 function StatusItem({ label, value, unit, color }: StatusItemProps) {
   return (
-    <div className="flex h-[88px] min-w-0 flex-col items-center justify-center border-4 border-white bg-[#333333] shadow-[8px_8px_0_#000]">
+    <div className="bg-surface-sub flex h-[88px] min-w-0 flex-col items-center justify-center border-4 border-white shadow-[8px_8px_0_#000]">
       <p className={`mb-2 text-sm font-semibold ${color}`}>{label}</p>
 
-      <p className="text-xl font-semibold text-white">
+      <p className="text-text text-xl font-semibold">
         {value}
         {unit && <span className="ml-1 text-sm font-normal">{unit}</span>}
       </p>
@@ -20,7 +20,7 @@ export default function GameProgress({
   isWaiting = false,
 }: GameProgressProps) {
   return (
-    <section className="w-full max-w-[916px] border-4 border-black bg-[#454545] px-4 py-4 shadow-[8px_8px_0_#000] md:px-[22px] md:py-[19px]">
+    <section className="bg-surface-main w-full max-w-[916px] border-4 border-black px-4 py-4 shadow-[8px_8px_0_#000] md:px-[22px] md:py-[19px]">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 md:gap-6">
         {isWaiting ? (
           <>

--- a/apps/frontend/src/components/game/PracticeBox/PracticeBox.tsx
+++ b/apps/frontend/src/components/game/PracticeBox/PracticeBox.tsx
@@ -44,11 +44,11 @@ export default function PracticeBox({ initialMessages = [] }: PracticeBoxProps) 
   };
 
   return (
-    <section className="flex w-full max-w-[916px] flex-col gap-4 border-[4px] border-black bg-[#454545] p-4 shadow-[8px_8px_0px_#000] sm:p-6">
+    <section className="bg-surface-sub flex w-full max-w-[916px] flex-col gap-4 border-[4px] border-black p-4 shadow-[8px_8px_0px_#000] sm:p-6">
       <button
         type="button"
         onClick={handleFocusInput}
-        className="flex cursor-text items-center gap-4 text-left text-white"
+        className="text-text flex cursor-text items-center gap-4 text-left"
       >
         <Keyboard size={28} />
         <h2 className="text-[clamp(22px,2vw,32px)] font-semibold">연습장</h2>
@@ -57,14 +57,14 @@ export default function PracticeBox({ initialMessages = [] }: PracticeBoxProps) 
       <button
         type="button"
         onClick={handleFocusInput}
-        className="block border-[4px] border-black bg-[#3b3b3b] p-4 text-left sm:p-6"
+        className="bg-surface-main block border-[4px] border-black p-4 text-left sm:p-6"
       >
         <div ref={scrollRef} className="h-[clamp(180px,28vh,240px)] overflow-y-auto">
           <div className="flex flex-col gap-2">
             {messages.map((message) => (
               <p
                 key={message.id}
-                className="whitespace-pre-wrap break-keep text-[clamp(18px,1.8vw,24px)] leading-[1.45] text-white"
+                className="text-text whitespace-pre-wrap break-keep text-[clamp(18px,1.8vw,24px)] leading-[1.45]"
               >
                 {message.text}
               </p>
@@ -84,7 +84,7 @@ export default function PracticeBox({ initialMessages = [] }: PracticeBoxProps) 
           }
         }}
         placeholder="메시지를 입력하세요..."
-        className="h-[clamp(48px,7vh,60px)] w-full border-[4px] border-black bg-gray-200 px-4 text-[clamp(16px,1.6vw,20px)] text-black outline-none placeholder:text-gray-400"
+        className="bg-surface-main text-text h-[clamp(48px,7vh,60px)] w-full border-[4px] border-black px-4 text-[clamp(16px,1.6vw,20px)] outline-none placeholder:text-text/50"
       />
     </section>
   );

--- a/apps/frontend/src/components/game/RaceTrack/RaceTrack.tsx
+++ b/apps/frontend/src/components/game/RaceTrack/RaceTrack.tsx
@@ -1,14 +1,27 @@
+import char1 from "@/assets/icons/char1.svg";
+import char2 from "@/assets/icons/char2.svg";
+import char3 from "@/assets/icons/char3.svg";
+import char4 from "@/assets/icons/char4.svg";
+import char5 from "@/assets/icons/char5.svg";
+import char6 from "@/assets/icons/char6.svg";
+import char7 from "@/assets/icons/char7.svg";
+
+const CAR_ICONS = [char1, char2, char3, char4, char5, char6, char7];
+
 type RaceTrackProps = {
   progress: number;
+  carIndex?: number;
 };
 
-export default function RaceTrack({ progress }: RaceTrackProps) {
+export default function RaceTrack({ progress, carIndex = 0 }: RaceTrackProps) {
   const safeProgress = Math.min(100, Math.max(0, progress));
+
+  const selectedCar = CAR_ICONS[carIndex % CAR_ICONS.length];
 
   return (
     <section className="relative h-[87px] w-full max-w-[900px] overflow-visible">
       {/* 도로 */}
-      <div className="absolute left-[8%] right-[5.5%] top-1/2 h-[54px] -translate-y-1/2 bg-[#333333]">
+      <div className="absolute left-[8%] right-[5.5%] top-1/2 h-[54px] -translate-y-1/2 bg-surface-sub">
         {/* 위 빨간 라인 */}
         <div className="absolute inset-x-0 top-0 h-[8px] bg-[repeating-linear-gradient(to_right,#ff6b6b_0px,#ff6b6b_18px,white_18px,white_36px)]" />
 
@@ -21,11 +34,13 @@ export default function RaceTrack({ progress }: RaceTrackProps) {
 
       {/* 자동차 */}
       <img
-        src="/car-blue.png"
+        src={selectedCar}
         alt="player car"
         className="absolute top-1/2 z-20 h-[clamp(44px,8vw,72px)] w-auto -translate-y-1/2 transition-all duration-300"
+        draggable={false}
         style={{
           left: `calc(8% + (${safeProgress} / 100) * 80%)`,
+          imageRendering: "pixelated",
         }}
       />
 
@@ -33,7 +48,7 @@ export default function RaceTrack({ progress }: RaceTrackProps) {
       <div className="absolute right-[1.5%] top-1/2 z-10 flex h-[62px] -translate-y-1/2 items-center bg-white px-1">
         <div className="mr-1 flex h-full w-[18px] flex-col">
           <div className="h-1/2 bg-black" />
-          <div className="h-1/2 bg-[#333333]" />
+          <div className="h-1/2 bg-surface-sub" />
         </div>
 
         <span className="text-[13px] font-bold leading-[13px] text-yellow-400 [writing-mode:vertical-rl]">

--- a/apps/frontend/src/components/game/TypingGame/TypingGame.tsx
+++ b/apps/frontend/src/components/game/TypingGame/TypingGame.tsx
@@ -156,14 +156,14 @@ const TypingGame = ({ prompt, life, onInputChange, onWrongInput }: TypingGamePro
   };
 
   return (
-    <div className="flex min-w-0 w-full max-w-[916px] flex-col gap-3 border-[4px] border-black bg-[#454545] p-3 shadow-[8px_8px_0px_#000] sm:gap-4 sm:p-4 lg:p-6">
+    <div className="flex min-w-0 w-full max-w-[916px] flex-col gap-3 border-[4px] border-black bg-surface-sub p-3 shadow-[8px_8px_0px_#000] sm:gap-4 sm:p-4 lg:p-6">
       <div className="flex items-center justify-between">
-        <div className="text-xl text-white">⌨️</div>
+        <div className="text-xl text-text">⌨️</div>
 
         <HeartStatus life={life} />
       </div>
 
-      <div className="border-[4px] border-black bg-[#3b3b3b] p-6">
+      <div className="border-[4px] border-black bg-surface-main p-6">
         <div ref={containerRef} className="h-[clamp(160px,28vh,240px)] w-full overflow-hidden">
           <div className="whitespace-pre-wrap break-keep text-[clamp(18px,2vw,24px)] leading-[2.5]">
             {visibleLines.map((line, visibleLineIndex) => {
@@ -209,7 +209,7 @@ const TypingGame = ({ prompt, life, onInputChange, onWrongInput }: TypingGamePro
                           state === "composing" && "text-yellow-400",
                           state === "wrong" && "text-red-400",
                           state === "cursor" && "bg-yellow-300 text-black",
-                          state === "untyped" && "text-white",
+                          state === "untyped" && "text-text",
                         )}
                       >
                         {char}
@@ -231,7 +231,7 @@ const TypingGame = ({ prompt, life, onInputChange, onWrongInput }: TypingGamePro
         ref={inputRef}
         placeholder={isGameOver ? "Game Over" : "Start typing here..."}
         disabled={isGameOver}
-        className="h-[clamp(48px,7vh,60px)] w-full resize-none border-[4px] border-black bg-gray-200 px-4 py-3 text-[clamp(16px,1.6vw,20px)] font-bold text-black placeholder:text-gray-400 outline-none disabled:bg-gray-400"
+        className="h-[clamp(48px,7vh,60px)] w-full resize-none border-[4px] border-black bg-surface-main px-4 py-3 text-[clamp(16px,1.6vw,20px)] font-bold text-text placeholder:text-text/50 outline-none disabled:bg-surface-sub"
       />
     </div>
   );

--- a/apps/frontend/src/pages/GamePage.tsx
+++ b/apps/frontend/src/pages/GamePage.tsx
@@ -325,13 +325,13 @@ const GamePage = () => {
   const isPlaying = phase === "playing";
 
   return (
-    <div className="relative flex h-dvh w-full overflow-hidden bg-[#5D6F79]">
+    <div className="bg-surface-main relative flex h-dvh w-full overflow-hidden">
       <Link
         to={PATH.SETTING}
         aria-label="설정 페이지로 이동"
         className="absolute right-[72px] top-[30px] z-50 flex h-[47px] w-[47px] items-center justify-center"
       >
-        <Settings size={47} strokeWidth={2.5} className="text-[#3F3F3F]" />
+        <Settings size={47} strokeWidth={2.5} className="text-text" />
       </Link>
 
       <div className="h-full w-full p-6">
@@ -344,9 +344,9 @@ const GamePage = () => {
             <div className="w-full max-w-[1180px]">
               <div className="flex w-full flex-col items-center gap-6">
                 {isPlaying ? (
-                  <RaceTrack progress={progress} />
+                  <RaceTrack progress={progress} carIndex={0} />
                 ) : (
-                  <div className="flex h-[87px] w-full max-w-[900px] items-center justify-center text-center text-[clamp(28px,3vw,44px)] font-bold text-white drop-shadow-[3px_3px_0px_#000]">
+                  <div className="flex h-[87px] w-full max-w-[900px] items-center justify-center text-center text-[clamp(28px,3vw,44px)] font-bold text-text drop-shadow-[3px_3px_0px_#000]">
                     {waitingPlayerCount < MIN_PLAYERS ? (
                       <span className="text-yellow-400">참여자를 기다리는 중...</span>
                     ) : (
@@ -372,8 +372,8 @@ const GamePage = () => {
                 {phase === "waiting" && <PracticeBox />}
 
                 {phase === "countdown" && (
-                  <div className="flex h-[clamp(300px,52vh,420px)] w-full max-w-[916px] items-center justify-center border-[4px] border-black bg-[#454545] shadow-[8px_8px_0px_#000]">
-                    <span className="text-[clamp(80px,12vw,140px)] font-bold text-white drop-shadow-[4px_4px_0px_#000]">
+                  <div className="flex h-[clamp(300px,52vh,420px)] w-full max-w-[916px] items-center justify-center border-[4px] border-black bg-surface-sub shadow-[8px_8px_0px_#000]">
+                    <span className="text-[clamp(80px,12vw,140px)] font-bold text-text drop-shadow-[4px_4px_0px_#000]">
                       {countdown}
                     </span>
                   </div>


### PR DESCRIPTION
##  개요

게임 화면 전반에 다크모드 색상 토큰을 적용했습니다.

---

##  작업 내용

- GamePage 색상 토큰 적용
- GameProgress 색상 토큰 적용
- PracticeBox 색상 토큰 적용
- TypingGame 색상 토큰 적용
- RaceTrack 색상 토큰 적용
- 자동차 SVG 에셋 적용
- RaceTrack 차량 아이콘 확장 구조 추가

---

##  변경 사항

### 색상 토큰 적용

하드코딩된 색상 값을 아래 토큰 기반으로 변경했습니다.

- `bg-surface-main`
- `bg-surface-sub`
- `text-text`

### RaceTrack 개선

- `/car-blue.png` 제거
- SVG 차량 에셋 적용
- 차량 아이콘 확장 가능한 구조로 변경

---

## 📸 UI 스크린샷

### 다크모드 적용 후 게임 화면

- 게임 진행 화면
- 대기 화면
- 연습장 UI
- 타이핑 UI

---


## 체크리스트

- [x] 컨벤션 규칙에 맞게 작성했나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 로컬 테스트를 완료했나요?