### PR TITLE
[fix] 개선: 소켓 이벤트 핸들러 중복 등록 및 게임 상태 동기화 로직 수정

### DIFF
--- a/apps/frontend/src/hooks/useGame.ts
+++ b/apps/frontend/src/hooks/useGame.ts
@@ -23,7 +23,7 @@ export const useGameData = () => {
   const { data: game } = useGameDetail();
   const { data: scoreboard } = useScoreboard();
 
-  const { setParticipants, setPrompt, setWaitingState } = useGameStore();
+  const { setParticipants, setPrompt } = useGameStore();
 
   useEffect(() => {
     if (!game) return;
@@ -61,10 +61,5 @@ export const useGameData = () => {
     });
 
     setParticipants(mapped);
-
-    setWaitingState({
-      playerCount: participants.length,
-      remainingSeconds: game.remainingSeconds ?? 0,
-    });
-  }, [game, scoreboard, setParticipants, setPrompt, setWaitingState]);
+  }, [game, scoreboard, setParticipants, setPrompt]);
 };

--- a/apps/frontend/src/lib/socket/handlers/connection.handler.ts
+++ b/apps/frontend/src/lib/socket/handlers/connection.handler.ts
@@ -5,27 +5,28 @@ import { BATTLE_SOCKET_EVENTS } from "../socketEvents";
 export const registerConnectionHandlers = (socket: Socket) => {
   console.log("connection handler 등록");
 
+  socket.off("connect");
+  socket.off("disconnect");
+  socket.off("connect_error");
+  socket.off(BATTLE_SOCKET_EVENTS.ERROR);
+
   socket.on("connect", () => {
     console.log("socket connected", socket.id);
-
     useSocketStore.getState().setConnected(true);
   });
 
   socket.on("disconnect", (reason) => {
     console.log("socket disconnected", reason);
-
     useSocketStore.getState().setConnected(false);
   });
 
   socket.on("connect_error", (error) => {
     console.error("socket connect error", error);
-
     useSocketStore.getState().setError(error.message ?? "소켓 연결 실패");
   });
 
   socket.on(BATTLE_SOCKET_EVENTS.ERROR, (error) => {
     console.error("battle socket error", error);
-
     useSocketStore.getState().setError(error?.message ?? "소켓 에러가 발생했습니다.");
   });
 };

--- a/apps/frontend/src/lib/socket/handlers/game.handler.ts
+++ b/apps/frontend/src/lib/socket/handlers/game.handler.ts
@@ -1,5 +1,5 @@
 import type { Socket } from "socket.io-client";
-import { useGameStore } from "@/stores/useGameStore";
+import { type Participant, useGameStore } from "@/stores/useGameStore";
 import type {
   BattleParticipant,
   BattleStateLike,
@@ -12,11 +12,29 @@ import type {
   BattleStatePayload,
 } from "../socket.types";
 
+const mapParticipant = (participant: BattleParticipant): Participant => ({
+  participantId: participant.participantId,
+  nickname: participant.nickname ?? "플레이어",
+  progressPercent: participant.progressPercent ?? 0,
+  typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
+  wpm: participant.wpm ?? 0,
+  accuracy: participant.accuracy ?? 100,
+  life: participant.life ?? 3,
+  status: participant.status === "dead" ? "dead" : "playing",
+});
+
 export const registerGameHandlers = (socket: Socket) => {
+  socket.off("battle:state");
+  socket.off("battle:waiting");
+  socket.off("battle:started");
+  socket.off("battle:progress");
+  socket.off("battle:eliminated");
+  socket.off("battle:finished");
+
   socket.on("battle:state", (data: BattleStatePayload) => {
     console.log("[battle:state]", data);
-    const stateData = data as BattleStateLike;
 
+    const stateData = data as BattleStateLike;
     const promptContent = stateData.prompt?.content ?? "";
 
     if (promptContent) {
@@ -25,26 +43,17 @@ export const registerGameHandlers = (socket: Socket) => {
 
     useGameStore.getState().setPhase(stateData.phase);
 
+    const participants = stateData.participants ?? [];
+
     const playerCount =
-      stateData.participants?.length ?? stateData.waitingPlayerCount ?? stateData.playerCount ?? 0;
+      stateData.playerCount ?? stateData.waitingPlayerCount ?? participants.length;
 
     useGameStore.getState().setWaitingState({
       playerCount,
       remainingSeconds: stateData.remainingSeconds ?? stateData.countdown ?? 0,
     });
 
-    stateData.participants?.forEach((participant) => {
-      useGameStore.getState().updateParticipant({
-        participantId: participant.participantId,
-        nickname: participant.nickname ?? "플레이어",
-        progressPercent: participant.progressPercent ?? 0,
-        typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
-        wpm: participant.wpm ?? 0,
-        accuracy: participant.accuracy ?? 100,
-        life: participant.life ?? 3,
-        status: participant.status === "dead" ? "dead" : "playing",
-      });
-    });
+    useGameStore.getState().setParticipants(participants.map(mapParticipant));
   });
 
   socket.on("battle:waiting", (data?: BattleWaitingPayload) => {
@@ -81,16 +90,7 @@ export const registerGameHandlers = (socket: Socket) => {
 
     const participant = data.participant as BattleParticipant;
 
-    useGameStore.getState().updateParticipant({
-      participantId: participant.participantId,
-      nickname: participant.nickname ?? "플레이어",
-      progressPercent: participant.progressPercent ?? 0,
-      typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
-      wpm: participant.wpm ?? 0,
-      accuracy: participant.accuracy ?? 100,
-      life: participant.life ?? 3,
-      status: participant.status === "dead" ? "dead" : "playing",
-    });
+    useGameStore.getState().updateParticipant(mapParticipant(participant));
   });
 
   socket.on("battle:eliminated", (data: BattleEliminatedPayload) => {

--- a/apps/frontend/src/stores/useGameStore.ts
+++ b/apps/frontend/src/stores/useGameStore.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import type { BattlePhase } from "@/lib/socket/socket.types";
 
+const MIN_PLAYERS = 2;
+
 type GamePhase = BattlePhase | "countdown";
 
 export interface Participant {
@@ -12,8 +14,6 @@ export interface Participant {
   wpm: number;
   accuracy: number;
   life: number;
-
-  rank?: number;
 
   status?: "playing" | "dead";
 }
@@ -74,26 +74,16 @@ export const useGameStore = create<GameState>((set) => ({
       const isAlreadyInGame = state.phase === "in_progress" || state.phase === "finished";
 
       if (isAlreadyInGame) {
-        return {
-          waitingPlayerCount: playerCount,
-          countdown: remainingSeconds,
-        };
+        return state;
       }
 
-      // 최소 참가 인원 충족 전 → 항상 waiting
-      if (playerCount < 2) {
-        return {
-          waitingPlayerCount: playerCount,
-          countdown: remainingSeconds,
-          phase: "waiting",
-        };
-      }
+      const nextPhase: GamePhase =
+        playerCount < MIN_PLAYERS || remainingSeconds > 10 ? "waiting" : "countdown";
 
-      // 최소 참가 인원 충족 후
       return {
         waitingPlayerCount: playerCount,
         countdown: remainingSeconds,
-        phase: remainingSeconds <= 10 ? "countdown" : "waiting",
+        phase: nextPhase,
       };
     }),
 
@@ -123,7 +113,6 @@ export const useGameStore = create<GameState>((set) => ({
           wpm: data.wpm ?? 0,
           accuracy: data.accuracy ?? 100,
           life: data.life ?? 3,
-          rank: data.rank ?? 0,
           status: data.status ?? "playing",
         };
 


### PR DESCRIPTION
## 작업 내용

* 소켓 이벤트 핸들러 중복 등록 방지 처리
* 게임 상태 및 참가자 상태 관리 로직 개선
* waiting/countdown phase 전환 로직 리팩토링
* 불필요한 participant rank 상태 제거

## 상세 변경 사항

* `socket.off()` 추가를 통해 battle 이벤트 및 connection 이벤트 중복 등록 방지
* `battle:state` 이벤트 수신 시 participant 목록을 서버 상태 기준으로 교체하도록 수정
* `mapParticipant` 유틸 함수 분리로 participant 매핑 로직 공통화
* `useGameData`에서 waiting state를 직접 갱신하지 않도록 수정하여 socket 상태와 충돌 방지
* `setWaitingState` 내부 phase 계산 로직 정리
* 최소 참가 인원 상수(`MIN_PLAYERS`) 분리
* 사용되지 않는 `rank` 상태 제거

## 확인 사항

* socket reconnect 및 페이지 재진입 시 이벤트 중복 등록 여부 확인
* waiting/countdown phase 전환 정상 동작 확인
* participant 상태 업데이트 및 탈락 처리 정상 동작 확인
* game detail API 응답과 socket 상태 간 동기화 확인 필요

## 관련 이슈

* closes #

## 체크리스트

* [x] 컨벤션 규칙에 맞게 작성했나요?
* [x] 빌드가 정상적으로 통과되었나요?
* [x] 로컬 테스트를 완료했나요?
