### PR TITLE
[feat] 구현: 게임 종료 및 탈락 상태 UI 처리

### DIFF
--- a/apps/frontend/src/hooks/useGame.ts
+++ b/apps/frontend/src/hooks/useGame.ts
@@ -23,7 +23,7 @@ export const useGameData = () => {
   const { data: game } = useGameDetail();
   const { data: scoreboard } = useScoreboard();
 
-  const { setParticipants, setPrompt, setWaitingState } = useGameStore();
+  const { setParticipants, setPrompt } = useGameStore();
 
   useEffect(() => {
     if (!game) return;
@@ -61,10 +61,5 @@ export const useGameData = () => {
     });
 
     setParticipants(mapped);
-
-    setWaitingState({
-      playerCount: participants.length,
-      remainingSeconds: game.remainingSeconds ?? 0,
-    });
-  }, [game, scoreboard, setParticipants, setPrompt, setWaitingState]);
+  }, [game, scoreboard, setParticipants, setPrompt]);
 };

--- a/apps/frontend/src/lib/socket/handlers/connection.handler.ts
+++ b/apps/frontend/src/lib/socket/handlers/connection.handler.ts
@@ -5,27 +5,28 @@ import { BATTLE_SOCKET_EVENTS } from "../socketEvents";
 export const registerConnectionHandlers = (socket: Socket) => {
   console.log("connection handler 등록");
 
+  socket.off("connect");
+  socket.off("disconnect");
+  socket.off("connect_error");
+  socket.off(BATTLE_SOCKET_EVENTS.ERROR);
+
   socket.on("connect", () => {
     console.log("socket connected", socket.id);
-
     useSocketStore.getState().setConnected(true);
   });
 
   socket.on("disconnect", (reason) => {
     console.log("socket disconnected", reason);
-
     useSocketStore.getState().setConnected(false);
   });
 
   socket.on("connect_error", (error) => {
     console.error("socket connect error", error);
-
     useSocketStore.getState().setError(error.message ?? "소켓 연결 실패");
   });
 
   socket.on(BATTLE_SOCKET_EVENTS.ERROR, (error) => {
     console.error("battle socket error", error);
-
     useSocketStore.getState().setError(error?.message ?? "소켓 에러가 발생했습니다.");
   });
 };

--- a/apps/frontend/src/lib/socket/handlers/game.handler.ts
+++ b/apps/frontend/src/lib/socket/handlers/game.handler.ts
@@ -1,5 +1,5 @@
 import type { Socket } from "socket.io-client";
-import { useGameStore } from "@/stores/useGameStore";
+import { type Participant, useGameStore } from "@/stores/useGameStore";
 import type {
   BattleParticipant,
   BattleStateLike,
@@ -12,11 +12,29 @@ import type {
   BattleStatePayload,
 } from "../socket.types";
 
+const mapParticipant = (participant: BattleParticipant): Participant => ({
+  participantId: participant.participantId,
+  nickname: participant.nickname ?? "플레이어",
+  progressPercent: participant.progressPercent ?? 0,
+  typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
+  wpm: participant.wpm ?? 0,
+  accuracy: participant.accuracy ?? 100,
+  life: participant.life ?? 3,
+  status: participant.status === "dead" ? "dead" : "playing",
+});
+
 export const registerGameHandlers = (socket: Socket) => {
+  socket.off("battle:state");
+  socket.off("battle:waiting");
+  socket.off("battle:started");
+  socket.off("battle:progress");
+  socket.off("battle:eliminated");
+  socket.off("battle:finished");
+
   socket.on("battle:state", (data: BattleStatePayload) => {
     console.log("[battle:state]", data);
-    const stateData = data as BattleStateLike;
 
+    const stateData = data as BattleStateLike;
     const promptContent = stateData.prompt?.content ?? "";
 
     if (promptContent) {
@@ -25,26 +43,17 @@ export const registerGameHandlers = (socket: Socket) => {
 
     useGameStore.getState().setPhase(stateData.phase);
 
+    const participants = stateData.participants ?? [];
+
     const playerCount =
-      stateData.participants?.length ?? stateData.waitingPlayerCount ?? stateData.playerCount ?? 0;
+      stateData.playerCount ?? stateData.waitingPlayerCount ?? participants.length;
 
     useGameStore.getState().setWaitingState({
       playerCount,
       remainingSeconds: stateData.remainingSeconds ?? stateData.countdown ?? 0,
     });
 
-    stateData.participants?.forEach((participant) => {
-      useGameStore.getState().updateParticipant({
-        participantId: participant.participantId,
-        nickname: participant.nickname ?? "플레이어",
-        progressPercent: participant.progressPercent ?? 0,
-        typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
-        wpm: participant.wpm ?? 0,
-        accuracy: participant.accuracy ?? 100,
-        life: participant.life ?? 3,
-        status: participant.status === "dead" ? "dead" : "playing",
-      });
-    });
+    useGameStore.getState().setParticipants(participants.map(mapParticipant));
   });
 
   socket.on("battle:waiting", (data?: BattleWaitingPayload) => {
@@ -81,16 +90,7 @@ export const registerGameHandlers = (socket: Socket) => {
 
     const participant = data.participant as BattleParticipant;
 
-    useGameStore.getState().updateParticipant({
-      participantId: participant.participantId,
-      nickname: participant.nickname ?? "플레이어",
-      progressPercent: participant.progressPercent ?? 0,
-      typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
-      wpm: participant.wpm ?? 0,
-      accuracy: participant.accuracy ?? 100,
-      life: participant.life ?? 3,
-      status: participant.status === "dead" ? "dead" : "playing",
-    });
+    useGameStore.getState().updateParticipant(mapParticipant(participant));
   });
 
   socket.on("battle:eliminated", (data: BattleEliminatedPayload) => {

--- a/apps/frontend/src/pages/GamePage.tsx
+++ b/apps/frontend/src/pages/GamePage.tsx
@@ -59,6 +59,12 @@ const GamePage = () => {
   useEffect(() => {
     if (!socket || !myParticipant?.participantId) return;
 
+    const moveToGameLobby = () => {
+      window.setTimeout(() => {
+        navigate(PATH.GAME_LOBBY);
+      }, 1500);
+    };
+
     const handleEliminated = (data: { participantId: string }) => {
       if (data.participantId !== myParticipant.participantId) return;
 
@@ -69,16 +75,16 @@ const GamePage = () => {
       }, 1500);
     };
 
-    const handleFinished = () => {
-      setGameResult((prev) => {
-        if (prev === "gameOver") return prev;
+    const handleFinished = (data?: { winnerParticipantId?: string }) => {
+      const winnerParticipantId = data?.winnerParticipantId;
 
-        window.setTimeout(() => {
-          navigate(PATH.GAME_LOBBY);
-        }, 1500);
+      const isWinner = winnerParticipantId
+        ? winnerParticipantId === myParticipant.participantId
+        : myParticipant.progressPercent >= 100;
 
-        return "winner";
-      });
+      setGameResult(isWinner ? "winner" : "gameOver");
+
+      moveToGameLobby();
     };
 
     socket.on(BATTLE_SOCKET_EVENTS.ELIMINATED, handleEliminated);
@@ -88,7 +94,7 @@ const GamePage = () => {
       socket.off(BATTLE_SOCKET_EVENTS.ELIMINATED, handleEliminated);
       socket.off(BATTLE_SOCKET_EVENTS.FINISHED, handleFinished);
     };
-  }, [socket, myParticipant?.participantId, navigate]);
+  }, [socket, myParticipant, navigate]);
 
   const handleInputChange = (
     inputText: string,
@@ -126,7 +132,7 @@ const GamePage = () => {
       <div className="bg-surface-main flex h-dvh w-full items-center justify-center">
         <div className="rounded-2xl bg-white px-16 py-12 text-center shadow-lg">
           <h1 className="text-4xl font-bold text-red-500">Game Over</h1>
-          <p className="mt-4 text-lg text-gray-500">관전방으로 이동합니다...</p>
+          <p className="mt-4 text-lg text-gray-500">잠시 후 이동합니다...</p>
         </div>
       </div>
     );

--- a/apps/frontend/src/pages/GamePage.tsx
+++ b/apps/frontend/src/pages/GamePage.tsx
@@ -1,6 +1,6 @@
 import { Settings } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import SideBar from "@/components/common/Sidebar/SideBar";
 import { GameProgress } from "@/components/game/GameProgress";
 import { RaceTrack } from "@/components/game/RaceTrack";
@@ -10,6 +10,8 @@ import { useGameData } from "@/hooks/useGame";
 import { BATTLE_SOCKET_EVENTS } from "@/lib/socket/socketEvents";
 import { useGameStore } from "@/stores/useGameStore";
 import { useSocketStore } from "@/stores/useSocketStore";
+
+type GameResult = "playing" | "gameOver" | "winner";
 
 const formatTime = (seconds: number) => {
   const minutes = Math.floor(seconds / 60);
@@ -25,12 +27,13 @@ const getPromptLength = (prompt: string) => {
 const GamePage = () => {
   useGameData();
 
+  const navigate = useNavigate();
   const socket = useSocketStore((state) => state.socket);
 
   const prompt = useGameStore((state) => state.prompt);
   const participants = useGameStore((state) => state.participants);
-  console.log("socket.id:", socket?.id);
-  console.log("participants:", participants);
+
+  const [gameResult, setGameResult] = useState<GameResult>("playing");
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [localTypingCount, setLocalTypingCount] = useState(0);
   const [localAccuracy, setLocalAccuracy] = useState(100);
@@ -52,6 +55,40 @@ const GamePage = () => {
       window.clearInterval(timer);
     };
   }, []);
+
+  useEffect(() => {
+    if (!socket || !myParticipant?.participantId) return;
+
+    const handleEliminated = (data: { participantId: string }) => {
+      if (data.participantId !== myParticipant.participantId) return;
+
+      setGameResult("gameOver");
+
+      window.setTimeout(() => {
+        navigate(PATH.SPECTATE);
+      }, 1500);
+    };
+
+    const handleFinished = () => {
+      setGameResult((prev) => {
+        if (prev === "gameOver") return prev;
+
+        window.setTimeout(() => {
+          navigate(PATH.GAME_LOBBY);
+        }, 1500);
+
+        return "winner";
+      });
+    };
+
+    socket.on(BATTLE_SOCKET_EVENTS.ELIMINATED, handleEliminated);
+    socket.on(BATTLE_SOCKET_EVENTS.FINISHED, handleFinished);
+
+    return () => {
+      socket.off(BATTLE_SOCKET_EVENTS.ELIMINATED, handleEliminated);
+      socket.off(BATTLE_SOCKET_EVENTS.FINISHED, handleFinished);
+    };
+  }, [socket, myParticipant?.participantId, navigate]);
 
   const handleInputChange = (
     inputText: string,
@@ -83,6 +120,28 @@ const GamePage = () => {
   const handleWrongInput = () => {
     // 서버에서 life를 관리하므로 여기서는 별도 처리하지 않음
   };
+
+  if (gameResult === "gameOver") {
+    return (
+      <div className="bg-surface-main flex h-dvh w-full items-center justify-center">
+        <div className="rounded-2xl bg-white px-16 py-12 text-center shadow-lg">
+          <h1 className="text-4xl font-bold text-red-500">Game Over</h1>
+          <p className="mt-4 text-lg text-gray-500">관전방으로 이동합니다...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (gameResult === "winner") {
+    return (
+      <div className="bg-surface-main flex h-dvh w-full items-center justify-center">
+        <div className="rounded-2xl bg-white px-16 py-12 text-center shadow-lg">
+          <h1 className="text-4xl font-bold text-state-active">Victory!</h1>
+          <p className="mt-4 text-lg text-gray-500">대기방으로 이동합니다...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="bg-surface-main relative flex h-dvh w-full overflow-hidden">

--- a/apps/frontend/src/stores/useGameStore.ts
+++ b/apps/frontend/src/stores/useGameStore.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import type { BattlePhase } from "@/lib/socket/socket.types";
 
+const MIN_PLAYERS = 2;
+
 type GamePhase = BattlePhase | "countdown";
 
 export interface Participant {
@@ -12,8 +14,6 @@ export interface Participant {
   wpm: number;
   accuracy: number;
   life: number;
-
-  rank?: number;
 
   status?: "playing" | "dead";
 }
@@ -74,26 +74,16 @@ export const useGameStore = create<GameState>((set) => ({
       const isAlreadyInGame = state.phase === "in_progress" || state.phase === "finished";
 
       if (isAlreadyInGame) {
-        return {
-          waitingPlayerCount: playerCount,
-          countdown: remainingSeconds,
-        };
+        return state;
       }
 
-      // 최소 참가 인원 충족 전 → 항상 waiting
-      if (playerCount < 2) {
-        return {
-          waitingPlayerCount: playerCount,
-          countdown: remainingSeconds,
-          phase: "waiting",
-        };
-      }
+      const nextPhase: GamePhase =
+        playerCount < MIN_PLAYERS || remainingSeconds > 10 ? "waiting" : "countdown";
 
-      // 최소 참가 인원 충족 후
       return {
         waitingPlayerCount: playerCount,
         countdown: remainingSeconds,
-        phase: remainingSeconds <= 10 ? "countdown" : "waiting",
+        phase: nextPhase,
       };
     }),
 
@@ -123,7 +113,6 @@ export const useGameStore = create<GameState>((set) => ({
           wpm: data.wpm ?? 0,
           accuracy: data.accuracy ?? 100,
           life: data.life ?? 3,
-          rank: data.rank ?? 0,
           status: data.status ?? "playing",
         };
 


### PR DESCRIPTION
##  개요

게임 진행 중 탈락 및 게임 종료 시 상태에 따라 UI를 분기하고 페이지 이동을 처리했습니다.

##  작업 내용

* `battle:eliminated` 이벤트 수신 시 Game Over UI 표시 및 관전방 이동 처리
* `battle:finished` 이벤트 수신 시 Victory UI 표시 및 대기방 이동 처리
* `gameResult` 상태를 추가하여 게임 진행 / 탈락 / 승리 상태 분기
* 게임 결과 상태에 따라 조건부 렌더링 추가
* socket 이벤트 등록 및 cleanup 처리 추가

##  변경 사항

* 탈락 시 `Game Over` 화면이 표시된 후 `/spectate` 이동
* 승리 시 `Victory!` 화면이 표시된 후 `/lobby` 이동
* 게임 종료 이벤트 처리 로직 추가


## 체크리스트

* [x] 컨벤션 규칙에 맞게 작성했나요?
* [x] 빌드가 정상적으로 통과되었나요?
* [x] 로컬 테스트를 완료했나요?
