### PR TITLE
[fix] 개선: 타이핑 게임 socket 상태 동기화 및 participant 식별 안정화

### DIFF
--- a/apps/backend/src/modules/battle/services/battle.service.ts
+++ b/apps/backend/src/modules/battle/services/battle.service.ts
@@ -543,7 +543,7 @@ export class BattleService {
       nextWaitingStartsAt: null,
       phase: "waiting" as const,
       playerCount: 0,
-      minPlayers: 1, // default = 4
+      minPlayers: 4, // default = 4
       prompt,
       rankings: [],
       spectatorCount: 0,

--- a/apps/backend/src/modules/game-state/game-state.service.ts
+++ b/apps/backend/src/modules/game-state/game-state.service.ts
@@ -68,7 +68,7 @@ export class GameStateService {
         id: gameData?.gameId ?? 0,
         phase: gameData?.phase ?? "wait",
         startedAt: gameData?.gameStartedAt ?? "",
-        minPlayers: gameData?.minPlayers ?? 1,
+        minPlayers: gameData?.minPlayers ?? 4,
         playerCount: players.length,
         spectatorCount: spectators.length,
         waitingStartedAt: gameData?.waitingStartedAt ?? "",

--- a/apps/frontend/src/hooks/useEnterBattle.ts
+++ b/apps/frontend/src/hooks/useEnterBattle.ts
@@ -9,6 +9,10 @@ import { useSocketStore } from "@/stores/useSocketStore";
 
 let isEnteringBattle = false;
 
+const getNextPath = (phase: string) => {
+  return phase === "in_progress" ? PATH.SPECTATE : PATH.GAME_LOBBY;
+};
+
 export const useEnterBattle = () => {
   const navigate = useNavigate();
 
@@ -22,7 +26,7 @@ export const useEnterBattle = () => {
 
       if (currentSocket?.connected) {
         const game = await getGameDetail();
-        const nextPath = game.game.phase === "in_progress" ? PATH.GAME : PATH.GAME_LOBBY;
+        const nextPath = getNextPath(game.game.phase);
 
         navigate(nextPath, {
           replace: true,
@@ -41,7 +45,7 @@ export const useEnterBattle = () => {
       registerGameHandlers(socket);
 
       const game = await getGameDetail();
-      const nextPath = game.game.phase === "in_progress" ? PATH.GAME : PATH.GAME_LOBBY;
+      const nextPath = getNextPath(game.game.phase);
 
       navigate(nextPath, {
         replace: true,

--- a/apps/frontend/src/hooks/useEnterBattle.ts
+++ b/apps/frontend/src/hooks/useEnterBattle.ts
@@ -22,8 +22,9 @@ export const useEnterBattle = () => {
 
       if (currentSocket?.connected) {
         const game = await getGameDetail();
+        const nextPath = game.game.phase === "in_progress" ? PATH.GAME : PATH.GAME_LOBBY;
 
-        navigate(game.game.phase === "in_progress" ? PATH.SPECTATE : PATH.GAME_LOBBY, {
+        navigate(nextPath, {
           replace: true,
         });
 
@@ -33,19 +34,16 @@ export const useEnterBattle = () => {
       const { socketAuthToken } = await joinMatch();
 
       const socket = createBattleSocket(socketAuthToken);
-      console.log("소켓 생성됨", socket);
 
       useSocketStore.getState().connect(socket);
-      console.log("소켓 store 저장 완료");
 
       registerConnectionHandlers(socket);
       registerGameHandlers(socket);
 
-      console.log("소켓 핸들러 등록 완료");
-
       const game = await getGameDetail();
+      const nextPath = game.game.phase === "in_progress" ? PATH.GAME : PATH.GAME_LOBBY;
 
-      navigate(game.game.phase === "in_progress" ? PATH.SPECTATE : PATH.GAME_LOBBY, {
+      navigate(nextPath, {
         replace: true,
       });
     } finally {

--- a/apps/frontend/src/lib/socket/handlers/game.handler.ts
+++ b/apps/frontend/src/lib/socket/handlers/game.handler.ts
@@ -14,6 +14,8 @@ import type {
 
 const mapParticipant = (participant: BattleParticipant): Participant => ({
   participantId: participant.participantId,
+  ...(participant.socketId ? { socketId: participant.socketId } : {}),
+
   nickname: participant.nickname ?? "플레이어",
   progressPercent: participant.progressPercent ?? 0,
   typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
@@ -28,10 +30,15 @@ export const registerGameHandlers = (socket: Socket) => {
   socket.off("battle:waiting");
   socket.off("battle:started");
   socket.off("battle:progress");
+  socket.off("battle:input-result");
   socket.off("battle:eliminated");
   socket.off("battle:finished");
 
   socket.on("battle:state", (data: BattleStatePayload) => {
+    if (data?.gameId) {
+      useGameStore.getState().setGameId(data.gameId);
+    }
+
     console.log("[battle:state]", data);
 
     const stateData = data as BattleStateLike;
@@ -63,6 +70,10 @@ export const registerGameHandlers = (socket: Socket) => {
   });
 
   socket.on("battle:waiting", (data?: BattleWaitingPayload) => {
+    if (data?.gameId) {
+      useGameStore.getState().setGameId(data.gameId);
+    }
+
     console.log("[battle:waiting]", data);
 
     const playerCount =
@@ -82,6 +93,7 @@ export const registerGameHandlers = (socket: Socket) => {
   });
 
   socket.on("battle:started", (data: BattleStartedPayload) => {
+    useGameStore.getState().setGameId(data.gameId);
     const promptContent = data.prompt?.content ?? "";
 
     if (promptContent) {
@@ -99,6 +111,10 @@ export const registerGameHandlers = (socket: Socket) => {
     const participant = data.participant as BattleParticipant;
 
     useGameStore.getState().updateParticipant(mapParticipant(participant));
+  });
+
+  socket.on("battle:input-result", (data) => {
+    console.log("[battle:input-result]", data);
   });
 
   socket.on("battle:eliminated", (data: BattleEliminatedPayload) => {

--- a/apps/frontend/src/pages/GamePage.tsx
+++ b/apps/frontend/src/pages/GamePage.tsx
@@ -1,6 +1,5 @@
-import { Settings } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import SideBar from "@/components/common/Sidebar/SideBar";
 import { GameProgress } from "@/components/game/GameProgress";
 import { RaceTrack } from "@/components/game/RaceTrack";
@@ -32,6 +31,7 @@ const GamePage = () => {
 
   const prompt = useGameStore((state) => state.prompt);
   const participants = useGameStore((state) => state.participants);
+  const gameId = useGameStore((state) => state.gameId);
 
   const [gameResult, setGameResult] = useState<GameResult>("playing");
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
@@ -39,15 +39,18 @@ const GamePage = () => {
   const [localAccuracy, setLocalAccuracy] = useState(0);
   const [localProgress, setLocalProgress] = useState(0);
 
-  const myParticipant = participants[0];
-  console.log("participants", participants);
-  console.log("myParticipant", myParticipant);
-  console.log("participant keys", Object.keys(myParticipant ?? {}));
-  console.log("socket id", socket?.id);
+  const myParticipant =
+    participants.find((participant) => participant.socketId === socket?.id) ?? participants[0];
 
-  const progress = myParticipant?.progressPercent ?? localProgress;
+  const progress = Math.min(100, Math.max(0, myParticipant?.progressPercent ?? localProgress));
+
   const typingCount = myParticipant?.typedLength ?? localTypingCount;
-  const accuracy = typingCount === 0 ? 0 : (myParticipant?.accuracy ?? localAccuracy);
+
+  const accuracy = Math.min(
+    100,
+    Math.max(0, typingCount === 0 ? 0 : (myParticipant?.accuracy ?? localAccuracy)),
+  );
+
   const life = myParticipant?.life ?? 3;
 
   useEffect(() => {
@@ -106,10 +109,14 @@ const GamePage = () => {
     completedTypingCount = 0,
     completedCorrectCount = 0,
   ) => {
+    if (!gameId) {
+      console.warn("[battle:input skipped] gameId가 없습니다.");
+      return;
+    }
     socket?.emit(BATTLE_SOCKET_EVENTS.INPUT, {
-      inputText,
+      gameId,
+      typedText: inputText,
       cursorPosition: inputText.length,
-      typedChars: completedTypingCount + inputText.length,
     });
 
     const totalLength = getPromptLength(prompt);
@@ -155,14 +162,6 @@ const GamePage = () => {
 
   return (
     <div className="bg-surface-main relative flex h-dvh w-full overflow-hidden">
-      <Link
-        to={PATH.SETTING}
-        aria-label="설정 페이지로 이동"
-        className="absolute right-[72px] top-[30px] z-50 flex h-[47px] w-[47px] items-center justify-center"
-      >
-        <Settings size={47} strokeWidth={2.5} className="text-text" />
-      </Link>
-
       <div className="h-full w-full p-6">
         <div className="flex h-full w-full gap-8 overflow-hidden">
           <div className="w-[260px] shrink-0">

--- a/apps/frontend/src/stores/useGameStore.ts
+++ b/apps/frontend/src/stores/useGameStore.ts
@@ -1,24 +1,27 @@
 import { create } from "zustand";
 import type { BattlePhase } from "@/lib/socket/socket.types";
 
-const MIN_PLAYERS = 2;
+const MIN_PLAYERS = 4;
 
 type GamePhase = BattlePhase | "countdown";
 
 export interface Participant {
   participantId: string;
-  nickname: string;
+  socketId?: string;
 
+  nickname: string;
   progressPercent: number;
   typedLength: number;
   wpm: number;
   accuracy: number;
   life: number;
-
+  rank?: number;
   status?: "playing" | "dead";
 }
 
 interface GameState {
+  gameId: string | null;
+
   phase: GamePhase;
 
   prompt: string;
@@ -30,6 +33,8 @@ interface GameState {
 
   previousWinner: string;
   previousGameDuration: string;
+
+  setGameId: (gameId: string | null) => void;
 
   setPrompt: (prompt: string) => void;
 
@@ -51,6 +56,8 @@ interface GameState {
 }
 
 export const useGameStore = create<GameState>((set) => ({
+  gameId: null,
+
   phase: "waiting",
 
   prompt: "",
@@ -62,6 +69,8 @@ export const useGameStore = create<GameState>((set) => ({
 
   previousWinner: "-",
   previousGameDuration: "00:00",
+
+  setGameId: (gameId) => set({ gameId }),
 
   setPrompt: (prompt) => set({ prompt }),
 
@@ -114,6 +123,7 @@ export const useGameStore = create<GameState>((set) => ({
           accuracy: data.accuracy ?? 100,
           life: data.life ?? 3,
           status: data.status ?? "playing",
+          ...(data.socketId ? { socketId: data.socketId } : {}),
         };
 
         return {

--- a/apps/frontend/src/types/socket/battle.ts
+++ b/apps/frontend/src/types/socket/battle.ts
@@ -1,7 +1,10 @@
 export type BattleParticipant = {
   participantId: string;
+  socketId?: string;
+  gameId?: string;
 
   nickname?: string;
+  role?: string;
 
   progressPercent?: number;
 
@@ -12,13 +15,20 @@ export type BattleParticipant = {
   accuracy?: number;
 
   life?: number;
+  typoCount?: number;
+  lastPenaltyIndex?: number | null;
 
   status?: string;
+
+  lastInputAt?: string;
+  eliminatedAt?: string | null;
+  finishedAt?: string | null;
 };
 
 export type BattleWaitingPayload = {
-  playerCount?: number;
+  gameId?: string;
 
+  playerCount?: number;
   waitingPlayerCount?: number;
 
   remainingSeconds?: number;
@@ -26,6 +36,8 @@ export type BattleWaitingPayload = {
 };
 
 export type BattleStateLike = {
+  gameId?: string;
+
   phase: "waiting" | "countdown" | "in_progress" | "finished";
 
   prompt?: {


### PR DESCRIPTION
## 작업 내용

* 타이핑 게임 socket 이벤트 흐름 및 participant 상태 동기화 로직을 개선했습니다.
* socketId 기반 participant 식별 구조를 추가해 멀티 플레이 환경에서 안정적으로 자신의 상태를 찾을 수 있도록 수정했습니다.
* 게임 화면 UI 및 디버깅 코드를 정리했습니다.

## 상세 변경 사항

* `gameId`를 socket payload/store에 저장하도록 수정
* `battle:input` emit 시 `gameId` 포함하도록 수정
* `GAME_MISMATCH` 문제 해결 및 `battle:progress` 정상 수신 확인
* `socketId` 기반 participant 식별 구조 추가
* `participants[0]` 의존 제거 및 현재 socket 기준 participant 탐색 방식 적용
* `progress`, `accuracy` 값 clamp 처리 추가
* socket 타입 및 participant 타입 확장
* `useEnterBattle` 디버깅 로그 제거 및 정식 흐름 정리
* `GamePage` 설정 버튼 제거 및 불필요 import 정리
* socket/game 디버깅 로그 정리

## 테스트

* `battle:input` emit 정상 확인
* `battle:progress` 실시간 수신 및 UI 반영 확인
* `socketId === socket.id` 기반 participant 매칭 확인
* 정확도/진행률 clamp 정상 동작 확인
* 멀티 플레이 환경 participant 상태 동기화 확인

## 관련 이슈

* closes #

## 체크리스트

* [x] 컨벤션 규칙에 맞게 작성했나요?
* [x] 빌드가 정상적으로 통과되었나요?
* [x] 로컬 테스트를 완료했나요?
