### PR TITLE
Feature/spectate api socket

### DIFF
--- a/apps/frontend/src/api/game.api.ts
+++ b/apps/frontend/src/api/game.api.ts
@@ -5,11 +5,18 @@ import type { ScoreboardItem } from "@/types/game/scoreboard";
 // 게임 기본 정보
 export const getGameDetail = async () => {
   const data = await api.get<GameDetailResponse>("/v1/games/current");
+  console.log("API raw:", data.data);
   return data.data;
 };
 
-// 참가자 목록
+// 참가자 목록 (순위)
 export const getScoreBoard = async () => {
   const data = await api.get<ScoreboardItem[]>("/v1/games/current/scoreboard");
+  return data.data;
+};
+
+// 관전자 목록
+export const getSpectators = async () => {
+  const data = await api.get<ScoreboardItem[]>("/v1/games/current/spectators");
   return data.data;
 };

--- a/apps/frontend/src/api/match.api.ts
+++ b/apps/frontend/src/api/match.api.ts
@@ -1,4 +1,5 @@
 import { api } from "@/lib/api";
+import type { MatchUser } from "@/types/game/user";
 
 type JoinMatchResponse = {
   socketAuthToken: string;
@@ -8,4 +9,11 @@ export const joinMatch = async () => {
   const { data } = await api.post<JoinMatchResponse>("/v1/match/join");
 
   return data;
+};
+
+// 대기자 목록
+export const getUsers = async () => {
+  const data = await api.get<MatchUser>("/v1/match/users");
+  // console.log("API raw:", data.data);
+  return data.data;
 };

--- a/apps/frontend/src/components/common/HeartIcons.tsx
+++ b/apps/frontend/src/components/common/HeartIcons.tsx
@@ -11,7 +11,7 @@ const sizeMap = {
   lg: "w-6 h-6",
 };
 
-const HeartIcons = ({ life, size = "sm" }: HeartIconsProps) => {
+const HeartIcons = ({ life = 3, size = "sm" }: HeartIconsProps) => {
   const hearts = Array.from({ length: life }, (_, i) => ({
     id: i, // key용
   }));

--- a/apps/frontend/src/components/common/ProgressBar.tsx
+++ b/apps/frontend/src/components/common/ProgressBar.tsx
@@ -10,17 +10,17 @@ const ProgressBar = ({ progress }: ProgressBarProps) => {
       {/* 차량 아이콘 */}
       <div className="relative h-3 mb-4 z-10">
         <div
-          className="absolute -top-0.5 transition-all duration-500"
-          style={{ left: `calc(${progress}% - 18px)` }}
+          className="absolute top-0.5 transition-[all] duration-500"
+          style={{ left: `calc(${progress}% - 15px)` }}
         >
           <span>
-            <img src={char1} alt="car" className="w-9" />
+            <img src={char1} alt="car" className="w-[32px]" />
           </span>
         </div>
       </div>
 
       {/* 진행바 */}
-      <div className="relative h-1.5 bg-black/30 overflow-hidden z-0">
+      <div className="relative h-1.5 bg-black/30  z-0">
         <div
           className="absolute inset-y-0 left-0 bg-state-active transition-all duration-500"
           style={{ width: `${progress}%` }}

--- a/apps/frontend/src/components/common/Sidebar/RoomInfo.tsx
+++ b/apps/frontend/src/components/common/Sidebar/RoomInfo.tsx
@@ -1,22 +1,23 @@
 import { useGameStore } from "@/stores/useGameStore";
+import type { PageMode } from "@/types";
 
-interface RoomStats {
+interface GameStats {
   alive: number;
   dead: number;
   waiting: number;
 }
 
-interface GameStats {
+interface RoomStats {
   waiting: number;
   language: string;
 }
 
 interface RoomInfoProps {
-  mode: "game" | "watch" | "waiting";
+  mode: PageMode;
   stats?: RoomStats | GameStats;
 }
 
-const RoomInfo = ({ mode, stats }: RoomInfoProps) => {
+const RoomInfo = ({ mode }: RoomInfoProps) => {
   const participants = useGameStore((state) => state.participants);
   const waitingPlayerCount = useGameStore((state) => state.waitingPlayerCount);
 
@@ -26,8 +27,7 @@ const RoomInfo = ({ mode, stats }: RoomInfoProps) => {
   const deadCount = participants.filter((p) => p.life <= 0).length;
 
   const displayStats =
-    stats ??
-    (mode === "watch"
+    mode === "spectate" || mode === "game"
       ? {
           alive: aliveCount,
           dead: deadCount,
@@ -36,44 +36,44 @@ const RoomInfo = ({ mode, stats }: RoomInfoProps) => {
       : {
           waiting: playerCount,
           language: "한국어",
-        });
+        };
 
   return (
     <section className="w-[220px] flex-shrink-0 border-4 border-black bg-surface-main px-3 py-3 shadow-[8px_8px_0_#000] ">
       <h3 className="text-sm font-semibold text-text mb-3">방 정보</h3>
 
       <div className="h-[7rem] flex flex-col justify-center border-4 border-black bg-surface-sub px-4 py-4 space-y-2 shadow-[inset_-4px_-4px_0_rgba(255,255,255,0.5),inset_4px_4px_0_rgba(0,0,0,0.1)]">
-        {mode === "watch" && (
+        {["game", "spectate"].includes(mode) && (
           <>
             <div className="flex justify-between items-center">
               <span className="text-xs font-medium text-text/70">생존자</span>
               <span className="text-sm font-normal text-point-mint">
-                {(displayStats as RoomStats).alive}
+                {(displayStats as GameStats).alive}
               </span>
             </div>
 
             <div className="flex justify-between items-center">
               <span className="text-xs font-medium text-text/70">사망자</span>
               <span className="text-sm font-normal text-point-red">
-                {(displayStats as RoomStats).dead}
+                {(displayStats as GameStats).dead}
               </span>
             </div>
 
             <div className="flex justify-between items-center">
               <span className="text-xs font-medium text-text/70">대기자</span>
               <span className="text-sm font-normal text-point-yellow">
-                {(displayStats as RoomStats).waiting}
+                {(displayStats as GameStats).waiting}
               </span>
             </div>
           </>
         )}
 
-        {["game", "waiting"].includes(mode) && (
+        {mode === "waiting" && (
           <>
             <div className="flex justify-between items-center">
               <span className="text-xs font-medium text-text/70">대기자</span>
               <span className="text-sm font-normal text-point-yellow">
-                {(displayStats as GameStats).waiting}
+                {(displayStats as RoomStats).waiting}
               </span>
             </div>
 
@@ -82,7 +82,7 @@ const RoomInfo = ({ mode, stats }: RoomInfoProps) => {
             <div className="flex justify-between items-center">
               <span className="text-xs font-medium text-text/70">언어</span>
               <span className="text-sm font-normal text-text">
-                {(displayStats as GameStats).language}
+                {(displayStats as RoomStats).language}
               </span>
             </div>
           </>

--- a/apps/frontend/src/components/common/Sidebar/SideBar.tsx
+++ b/apps/frontend/src/components/common/Sidebar/SideBar.tsx
@@ -1,7 +1,7 @@
 import type { PageMode } from "@/types";
 
 import RoomInfo from "./RoomInfo";
-import { UserListPanel } from "./userList";
+import UserListPanel from "./userList/UserListPanel";
 
 interface SidebarProps {
   mode: PageMode;

--- a/apps/frontend/src/components/common/Sidebar/userList/UserListPanel.tsx
+++ b/apps/frontend/src/components/common/Sidebar/userList/UserListPanel.tsx
@@ -144,10 +144,10 @@ const UserListPanel = ({ mode, players, waiting }: UserListPanelProps) => {
   type TabType = "players" | "waiting";
 
   const [currentTab, setCurrentTab] = useState<TabType>(
-    mode === "game" || mode === "watch" ? "players" : "waiting",
+    mode === "game" || mode === "spectate" ? "players" : "waiting",
   );
 
-  const isWatchMode = mode === "watch";
+  const isWatchMode = mode === "spectate";
   const isWaitingMode = mode === "waiting";
 
   return (

--- a/apps/frontend/src/components/common/Sidebar/userList/index.ts
+++ b/apps/frontend/src/components/common/Sidebar/userList/index.ts
@@ -1,3 +1,0 @@
-export type { PageMode } from "../../../../types/common";
-export type { Player } from "../../../../types/game/player";
-export { default as UserListPanel } from "./UserListPanel";

--- a/apps/frontend/src/components/spectator/ParticipantCard.tsx
+++ b/apps/frontend/src/components/spectator/ParticipantCard.tsx
@@ -5,81 +5,103 @@ interface Props {
   nickname: string;
   progress: number;
   wpm: number;
-  typedLength: number;
-  promptText?: string;
+  acceptedLength: number;
+  promptText: string;
   life: number;
 }
 
-const ParticipantCard = ({
-  nickname,
-  progress,
-  wpm,
-  typedLength,
-  promptText = "",
-  life,
-}: Props) => {
-  const renderPromptProgress = (text = "", typedLength = 0) => {
-    const safeTypedLength = Math.max(0, typedLength);
+const ParticipantCard = ({ nickname, progress, wpm, acceptedLength, promptText, life }: Props) => {
+  // 테스트
+  // const [testLength, setTestLength] = useState(0);
 
-    const correct = text.slice(0, safeTypedLength);
-    const rest = text.slice(safeTypedLength);
+  //   useEffect(() => {
+  //   const interval = setInterval(() => {
+  //     setTestLength((prev) => {
+  //       if (prev >= promptText.length) return prev; // 끝나면 멈춤
+  //       return prev + 1;
+  //     });
+  //   }, 70); // 👉 속도 조절 (작을수록 빠름)
+
+  //   return () => clearInterval(interval);
+  // }, [promptText]);
+
+  const getVisibleText = (text: string, typedLength: number, maxLines = 4) => {
+    const charsPerLine = 24;
+
+    const currentLine = Math.floor(typedLength / charsPerLine);
+
+    const half = Math.floor(maxLines / 2);
+
+    const startLine = Math.max(0, currentLine - half);
+    const endLine = currentLine + 1;
+
+    const startIdx = startLine * charsPerLine;
+    const endIdx = endLine * charsPerLine;
+
+    return {
+      visibleText: text.slice(startIdx, endIdx),
+      startIdx,
+    };
+  };
+
+  const renderPromptProgress = (text = "", acceptedLength = 0) => {
+    const { visibleText, startIdx } = getVisibleText(text, acceptedLength, 4);
+
+    const relativeTyped = acceptedLength - startIdx;
+
+    const correct = visibleText.slice(0, relativeTyped);
+    const rest = visibleText.slice(relativeTyped);
 
     return (
-      <span>
+      <div>
         <span className="text-state-active">{correct}</span>
         <span className="text-gray-500">{rest}</span>
-      </span>
+      </div>
     );
   };
 
   return (
-    <div className="w-full max-w-[320px]">
-      <div className="mb-1 flex items-center justify-between px-2">
-        <span className="max-w-[210px] truncate text-sm font-semibold text-white">{nickname}</span>
-
+    <div className="w-full">
+      <div className="flex justify-between items-center mb-1 px-2">
+        <span className="text-white text-sm font-semibold">{nickname}</span>
         <HeartIcons life={life} size="md" />
       </div>
 
       <div
         className="
-          flex
-          h-[260px]
-          w-full
-          flex-col
-          border-[3px]
-          border-black
+          w-full max-w-[320px]
           bg-[#2f2f2f]
-          px-4
-          py-3
+          px-4 py-3
+          border-[3px] border-black
           shadow-[6px_6px_0_#000]
         "
       >
+        {/* 문장 진행 표시 */}
         <div
-          className="
-            mb-3
-            flex-1
-            overflow-y-auto
-            pr-2
-            text-sm
-            leading-snug
-
-            [&::-webkit-scrollbar]:w-2
-            [&::-webkit-scrollbar-track]:bg-[#242424]
-            [&::-webkit-scrollbar-thumb]:bg-[#777]
-            [&::-webkit-scrollbar-thumb]:border
-            [&::-webkit-scrollbar-thumb]:border-black
-          "
+          className="text-[14px] mb-5 leading-relaxed break-all"
+          style={{
+            height: "6.5em",
+            overflow: "hidden",
+          }}
         >
-          {renderPromptProgress(promptText, typedLength)}
+          {renderPromptProgress(promptText, acceptedLength)}
+          {/* 테스트 */}
+          {/* {renderPromptProgress(promptText,testLength )} */}
         </div>
 
-        <div className="shrink-0">
-          <div className="mb-1 text-xs text-gray-300">
-            WPM: <span className="text-white">{wpm}</span>
-          </div>
-
-          <ProgressBar progress={progress} />
+        <div className="mb-0 text-xs text-gray-300">
+          WPM: <span className="text-white">{wpm}</span>
         </div>
+        <ProgressBar progress={progress} />
+
+        {/* 테스트 */}
+        {/* <ProgressBar
+          progress={
+            promptText.length === 0
+              ? 0
+              : (testLength / promptText.length) * 100
+          }
+        /> */}
       </div>
     </div>
   );

--- a/apps/frontend/src/hooks/useGame.ts
+++ b/apps/frontend/src/hooks/useGame.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { getGameDetail, getScoreBoard } from "@/api/game.api";
-import { type Participant, useGameStore } from "@/stores/useGameStore";
+import { useGameStore } from "@/stores/useGameStore";
+import type { Participant } from "@/types/game/participant";
 
 export const useGameDetail = () => {
   return useQuery({
@@ -28,8 +29,8 @@ export const useGameData = () => {
   useEffect(() => {
     if (!game) return;
 
-    if (game.prompt?.text) {
-      setPrompt(game.prompt.text);
+    if (game.prompt?.content) {
+      setPrompt(game.prompt.content);
     }
 
     const scoreboardMap = new Map(scoreboard?.map((score) => [score.userId, score]) ?? []);
@@ -42,21 +43,21 @@ export const useGameData = () => {
       ? participants.filter((participant) => scoreboardMap.has(participant.userId))
       : participants;
 
-    const mapped: Participant[] = playingParticipants.map((participant) => {
-      const score = scoreboardMap.get(participant.userId);
+    const mapped: Participant[] = playingParticipants.map((p) => {
+      const score = scoreboardMap.get(p.userId);
 
-      const life = score?.life ?? participant.life ?? 3;
+      const life = score?.life ?? p.life ?? 3;
 
       return {
-        participantId: participant.userId,
-        nickname: participant.nickname,
-        typedLength: participant.typedLength ?? 0,
-        progressPercent: participant.progressPercent ?? 0,
-        wpm: score?.wpm ?? participant.wpm ?? 0,
-        life,
-        rank: score?.rank ?? participant.rank ?? 0,
-        accuracy: score?.accuracy ?? participant.accuracy ?? 100,
-        status: life === 0 ? "dead" : "playing",
+        participantId: p.userId,
+        nickname: p.nickname,
+        acceptedLength: p.acceptedLength ?? 0,
+        progressPercent: p.progressPercent ?? 0,
+        wpm: score?.wpm ?? p.wpm ?? 0,
+        life: p.life,
+        rank: score?.rank ?? p.rank ?? 0,
+        accuracy: score?.accuracy ?? p.accuracy ?? 100,
+        status: life === 0 ? "eliminated" : "playing",
       };
     });
 

--- a/apps/frontend/src/lib/socket/handlers/game.handler.ts
+++ b/apps/frontend/src/lib/socket/handlers/game.handler.ts
@@ -1,5 +1,6 @@
 import type { Socket } from "socket.io-client";
-import { type Participant, useGameStore } from "@/stores/useGameStore";
+import { useGameStore } from "@/stores/useGameStore";
+import type { Participant } from "@/types/game/participant";
 import type {
   BattleParticipant,
   BattleStateLike,
@@ -16,14 +17,15 @@ const mapParticipant = (participant: BattleParticipant): Participant => ({
   participantId: participant.participantId,
   nickname: participant.nickname ?? "플레이어",
   progressPercent: participant.progressPercent ?? 0,
-  typedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
+  acceptedLength: participant.acceptedLength ?? participant.typedLength ?? 0,
   wpm: participant.wpm ?? 0,
   accuracy: participant.accuracy ?? 100,
   life: participant.life ?? 3,
-  status: participant.status === "dead" ? "dead" : "playing",
+  status: participant.status,
 });
 
 export const registerGameHandlers = (socket: Socket) => {
+  const store = useGameStore.getState();
   socket.off("battle:state");
   socket.off("battle:waiting");
   socket.off("battle:started");
@@ -38,10 +40,10 @@ export const registerGameHandlers = (socket: Socket) => {
     const promptContent = stateData.prompt?.content ?? "";
 
     if (promptContent) {
-      useGameStore.getState().setPrompt(promptContent);
+      store.setPrompt(promptContent);
     }
 
-    useGameStore.getState().setPhase(stateData.phase);
+    store.setPhase(stateData.phase);
 
     const participants = stateData.participants ?? [];
     console.log("[battle:state participants]", {
@@ -54,19 +56,18 @@ export const registerGameHandlers = (socket: Socket) => {
     const playerCount =
       stateData.playerCount ?? stateData.waitingPlayerCount ?? participants.length;
 
-    useGameStore.getState().setWaitingState({
+    store.setWaitingState({
       playerCount,
       remainingSeconds: stateData.remainingSeconds ?? stateData.countdown ?? 0,
     });
 
-    useGameStore.getState().setParticipants(participants.map(mapParticipant));
+    store.setParticipants(participants.map(mapParticipant));
   });
 
   socket.on("battle:waiting", (data?: BattleWaitingPayload) => {
     console.log("[battle:waiting]", data);
 
-    const playerCount =
-      data?.playerCount ?? data?.waitingPlayerCount ?? useGameStore.getState().participants.length;
+    const playerCount = data?.playerCount ?? data?.waitingPlayerCount ?? store.participants.length;
 
     const remainingSeconds = data?.remainingSeconds ?? data?.countdown ?? 0;
 
@@ -75,7 +76,7 @@ export const registerGameHandlers = (socket: Socket) => {
       remainingSeconds,
     });
 
-    useGameStore.getState().setWaitingState({
+    store.setWaitingState({
       playerCount,
       remainingSeconds,
     });
@@ -85,10 +86,10 @@ export const registerGameHandlers = (socket: Socket) => {
     const promptContent = data.prompt?.content ?? "";
 
     if (promptContent) {
-      useGameStore.getState().setPrompt(promptContent);
+      store.setPrompt(promptContent);
     }
 
-    useGameStore.getState().setPhase("in_progress");
+    store.setPhase("in_progress");
   });
 
   socket.on("battle:progress", (data: BattleProgressPayload) => {
@@ -98,14 +99,14 @@ export const registerGameHandlers = (socket: Socket) => {
 
     const participant = data.participant as BattleParticipant;
 
-    useGameStore.getState().updateParticipant(mapParticipant(participant));
+    store.updateParticipant(mapParticipant(participant));
   });
 
   socket.on("battle:eliminated", (data: BattleEliminatedPayload) => {
-    useGameStore.getState().eliminateParticipant(data.participantId);
+    store.eliminateParticipant(data.participantId);
   });
 
   socket.on("battle:finished", () => {
-    useGameStore.getState().setPhase("finished");
+    store.setPhase("finished");
   });
 };

--- a/apps/frontend/src/lib/socket/socket.types.ts
+++ b/apps/frontend/src/lib/socket/socket.types.ts
@@ -1,12 +1,6 @@
-export type BattlePhase = "waiting" | "in_progress" | "finished";
+import type { Status } from "@/types/game/gameDetail";
 
-// export interface BattleWaitingPayload {
-//   gameId: string;
-//   phase: BattlePhase;
-//   remainingSeconds: number;
-//   playerCount: number;
-//   spectatorCount: number;
-// }
+export type BattlePhase = "waiting" | "in_progress" | "finished";
 
 export interface BattleStatePayload {
   gameId: string;
@@ -65,7 +59,7 @@ export interface BattleProgressPayload {
     participantId: string;
     socketId: string;
     role: "player" | "spectator";
-    status: "playing" | "dead";
+    status: Status;
 
     acceptedLength: number;
     progressPercent: number;

--- a/apps/frontend/src/pages/GamePage.tsx
+++ b/apps/frontend/src/pages/GamePage.tsx
@@ -46,7 +46,7 @@ const GamePage = () => {
   console.log("socket id", socket?.id);
 
   const progress = myParticipant?.progressPercent ?? localProgress;
-  const typingCount = myParticipant?.typedLength ?? localTypingCount;
+  const typingCount = myParticipant?.acceptedLength ?? localTypingCount;
   const accuracy = typingCount === 0 ? 0 : (myParticipant?.accuracy ?? localAccuracy);
   const life = myParticipant?.life ?? 3;
 

--- a/apps/frontend/src/pages/SpectatePage.tsx
+++ b/apps/frontend/src/pages/SpectatePage.tsx
@@ -1,62 +1,14 @@
-import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import type { Socket } from "socket.io-client";
-
 import settingIcon from "@/assets/icons/settingIcon.svg";
 import BgImage from "@/assets/images/racing_night.svg";
-
 import SideBar from "@/components/common/Sidebar/SideBar";
 import ParticipantCard from "@/components/spectator/ParticipantCard";
-
 import { PATH } from "@/constants/route";
 import { useGameData } from "@/hooks/useGame";
-
-import { createBattleSocket } from "@/lib/socket/battleSocket";
-import type { BattleProgressPayload } from "@/lib/socket/socket.types";
-
-import { useAuthStore } from "@/stores/useAuthStore";
 import { useGameStore } from "@/stores/useGameStore";
 
 const SpectatePage = () => {
   const navigate = useNavigate();
-  const accessToken = useAuthStore((s) => s.accessToken);
-
-  // socket
-  useEffect(() => {
-    if (!accessToken) return;
-
-    let socket: Socket | null = null;
-
-    const connectSocket = async () => {
-      const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
-
-      // 매치 참가
-      const joinRes = await fetch(`${apiBaseUrl}/v1/match/join`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      const joinData = await joinRes.json();
-      const socketAuthToken = joinData.socketAuthToken;
-
-      // 소켓 연결
-      socket = createBattleSocket(socketAuthToken);
-
-      socket.on("battle:progress", (data: BattleProgressPayload) => {
-        const participant = data.participant;
-
-        useGameStore.getState().updateParticipant(participant);
-      });
-    };
-
-    connectSocket();
-
-    return () => {
-      if (socket) socket.disconnect();
-    };
-  }, [accessToken]);
 
   useGameData();
 
@@ -68,7 +20,7 @@ const SpectatePage = () => {
       className="relative flex h-screen overflow-hidden bg-cover bg-center"
       style={{ backgroundImage: `url(${BgImage})` }}
     >
-      <SideBar mode="watch" />
+      <SideBar mode="spectate" />
 
       {/* 참가자 카드 영역 */}
       <div className="relative flex-1 overflow-hidden px-10 pt-6 pb-6">
@@ -108,7 +60,7 @@ const SpectatePage = () => {
                 key={p.participantId}
                 nickname={p.nickname}
                 progress={p.progressPercent ?? 0}
-                typedLength={p.typedLength ?? 0}
+                acceptedLength={p.acceptedLength ?? 0}
                 wpm={p.wpm ?? 0}
                 promptText={prompt ?? ""}
                 life={p.life ?? 3}

--- a/apps/frontend/src/stores/useGameStore.ts
+++ b/apps/frontend/src/stores/useGameStore.ts
@@ -1,22 +1,10 @@
 import { create } from "zustand";
 import type { BattlePhase } from "@/lib/socket/socket.types";
+import type { Participant } from "@/types/game/participant";
 
 const MIN_PLAYERS = 2;
 
 type GamePhase = BattlePhase | "countdown";
-
-export interface Participant {
-  participantId: string;
-  nickname: string;
-
-  progressPercent: number;
-  typedLength: number;
-  wpm: number;
-  accuracy: number;
-  life: number;
-
-  status?: "playing" | "dead";
-}
 
 interface GameState {
   phase: GamePhase;
@@ -109,7 +97,7 @@ export const useGameStore = create<GameState>((set) => ({
           participantId: data.participantId,
           nickname: data.nickname ?? "",
           progressPercent: data.progressPercent ?? 0,
-          typedLength: data.typedLength ?? 0,
+          acceptedLength: data.acceptedLength ?? 0,
           wpm: data.wpm ?? 0,
           accuracy: data.accuracy ?? 100,
           life: data.life ?? 3,
@@ -140,7 +128,7 @@ export const useGameStore = create<GameState>((set) => ({
           ? {
               ...participant,
               life: 0,
-              status: "dead",
+              status: "eliminated",
             }
           : participant,
       ),

--- a/apps/frontend/src/types/common.ts
+++ b/apps/frontend/src/types/common.ts
@@ -1,1 +1,1 @@
-export type PageMode = "game" | "watch" | "waiting";
+export type PageMode = "game" | "spectate" | "waiting";

--- a/apps/frontend/src/types/game/gameDetail.ts
+++ b/apps/frontend/src/types/game/gameDetail.ts
@@ -1,36 +1,47 @@
+export type Status = "playing" | "finished" | "eliminated" | "spectating";
+
 export interface GameDetailResponse {
   game: {
-    id: number;
+    id: string;
     phase: "waiting" | "in_progress" | "finished";
+    startedAt: string;
     minPlayers: number;
-    totalPlayers: number;
+    playerCount: number;
     spectatorCount: number;
-    winnerUserId: string | null;
+
+    waitingStartedAt: string;
+    waitingEndsAt: string;
+
+    gameStartedAt: string;
+    gameEndedAt: string | null;
+
+    createdAt: string;
+    updatedAt: string;
   };
 
   prompt: {
     id: number;
-    text: string;
-    totalLength: number;
+    slug: string;
+    title: string;
+    content: string;
+    contentLength: number;
+    Language: string;
   };
 
   participants: {
     userId: string;
     nickname: string;
     avatarUrl: string;
-
+    status: Status;
     role: "player" | "spectator";
-
-    status: "waiting" | "alive" | "eliminated" | "finished" | "spectating" | "disconnected";
-
+    joinedAt: string;
     progressPercent: number;
-    typedLength: number;
-
     rank: number;
     wpm: number;
-    accuracy: number;
-
     life: number;
+    accuracy: number;
+    isEliminated: boolean;
+    acceptedLength: number;
   }[];
 
   remainingSeconds?: number;

--- a/apps/frontend/src/types/game/participant.ts
+++ b/apps/frontend/src/types/game/participant.ts
@@ -1,0 +1,11 @@
+export interface Participant {
+  participantId: string;
+  nickname: string;
+  progressPercent: number;
+  acceptedLength: number;
+  accuracy: number;
+  wpm: number;
+  life: number;
+  rank?: number;
+  status: "playing" | "finished" | "eliminated" | "spectating";
+}

--- a/apps/frontend/src/types/game/spectators.ts
+++ b/apps/frontend/src/types/game/spectators.ts
@@ -1,0 +1,5 @@
+export interface SpectatorUser {
+  userId: string;
+  nickname: string;
+  avatarUrl: string;
+}

--- a/apps/frontend/src/types/game/user.ts
+++ b/apps/frontend/src/types/game/user.ts
@@ -1,0 +1,21 @@
+export type UserStatus = "alive" | "dead";
+export type UserRole = "player" | "spectator";
+
+export interface MatchUser {
+  userId: string;
+  nickname: string;
+  avatarUrl: string;
+
+  status: UserStatus;
+  role: UserRole;
+
+  joinedAt: string;
+
+  progressPercent: number;
+  rank: number;
+  wpm: number;
+  life: number;
+  accuracy: number;
+
+  isEliminated: boolean;
+}

--- a/apps/frontend/src/types/socket/battle.ts
+++ b/apps/frontend/src/types/socket/battle.ts
@@ -13,7 +13,7 @@ export type BattleParticipant = {
 
   life?: number;
 
-  status?: string;
+  status: "playing" | "finished" | "eliminated" | "spectating";
 };
 
 export type BattleWaitingPayload = {


### PR DESCRIPTION
## 작업 내용
- API 응답 타입 불일치 문제 수정
- 서버 응답 스키마에 맞게 타입 정의 통일
- 관전 화면에서 참가자 타이핑 진행 상태 UI 개선

## 상세 변경 사항
### 1. API 타입 정리
- 기존: 일부 필드 타입 불일치 
- 수정: 서버 응답 기준으로 타입 통일
  - 참가자 typedLength -> acceptedLength
  - 프롬프트, 게임 등 수정

### 2. 관전 UI 개선
- 참가자 타이핑 진행 상태 표시 로직 유지
- 표시 줄 수 3줄 → 4줄로 확장
- 텍스트 가독성 개선 (폰트 크기 조정)

## 관련 이슈
- closes #

## 체크리스트
- [ ] 컨벤션 규칙에 맞게 작성했나요?
- [ ] 빌드가 정상적으로 통과되었나요?
- [ ] 로컬 테스트를 완료헀나요?