### PR TITLE
[fix] 수정: 로비 대기 인원 표시 기준 개선

### DIFF
--- a/apps/frontend/src/pages/GameLobbyPage.tsx
+++ b/apps/frontend/src/pages/GameLobbyPage.tsx
@@ -16,13 +16,12 @@ const GameLobbyPage = () => {
   useGameData();
 
   const phase = useGameStore((state) => state.phase);
-  const participants = useGameStore((state) => state.participants);
   const waitingPlayerCount = useGameStore((state) => state.waitingPlayerCount);
   const countdown = useGameStore((state) => state.countdown);
   const previousWinner = useGameStore((state) => state.previousWinner);
   const previousGameDuration = useGameStore((state) => state.previousGameDuration);
 
-  const playerCount = Math.max(waitingPlayerCount, participants.length);
+  const playerCount = waitingPlayerCount;
   const winnerText = previousWinner || "-";
   const durationText = previousGameDuration || "00:00";
 


### PR DESCRIPTION
## 작업 내용
- 로비 페이지의 대기 인원 표시 기준을 개선했습니다.

## 상세 변경 사항
- `GameLobbyPage`에서 `participants.length` 기반 인원 계산 제거
- 로비 인원 표시를 `waitingPlayerCount` 기준으로 통일
- stale participants 데이터로 인해 잘못된 인원 수가 표시되던 문제 완화
- 불필요한 `participants` store 구독 제거

## 변경 이유
기존에는 아래 코드로 대기 인원을 계산하고 있었습니다.

```ts
Math.max(waitingPlayerCount, participants.length)