### PR TITLE
[fix] 수정: 참가자 life 상태 동기화 오류 해결

### DIFF
--- a/apps/frontend/src/hooks/useGame.ts
+++ b/apps/frontend/src/hooks/useGame.ts
@@ -54,7 +54,7 @@ export const useGameData = () => {
         acceptedLength: p.acceptedLength ?? 0,
         progressPercent: p.progressPercent ?? 0,
         wpm: score?.wpm ?? p.wpm ?? 0,
-        life: p.life,
+        life,
         rank: score?.rank ?? p.rank ?? 0,
         accuracy: score?.accuracy ?? p.accuracy ?? 100,
         status: life === 0 ? "eliminated" : "playing",


### PR DESCRIPTION
## 작업 내용

* 참가자 life 상태가 정상적으로 반영되지 않던 문제를 수정했습니다.

## 상세 변경 사항

* scoreboard 기반으로 계산한 `life` 값을 실제 participant state에 반영하도록 수정
* 관전방 및 게임 화면에서 하트 상태와 elimination 상태가 동일한 기준을 사용하도록 정리

## 체크리스트

* [x] 컨벤션 규칙에 맞게 작성했나요?
* [x] 빌드가 정상적으로 통과되었나요?
* [x] 로컬 테스트를 완료했나요?
